### PR TITLE
Remove "page_size" and related counters from "perf_monitor"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2565,7 +2565,6 @@ version = "0.1.6"
 dependencies = [
  "kaspa-core",
  "log",
- "page_size",
  "portable-atomic",
  "thiserror",
  "tokio",
@@ -3657,16 +3656,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ad9b889f1b12e0b9ee24db044b5129150d5eada288edc800f789928dc8c0e3"
 dependencies = [
  "unicode-width",
-]
-
-[[package]]
-name = "page_size"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b7663cbd190cfd818d08efa8497f6cd383076688c49a391ef7c0d03cd12b561"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -5578,7 +5567,6 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "regex",
  "sha2 0.10.7",
  "syn 1.0.109",
  "workflow-macro-tools",
@@ -5797,7 +5785,6 @@ dependencies = [
  "js-sys",
  "numtoa",
  "nw-sys",
- "pad",
  "regex",
  "textwrap 0.16.0",
  "thiserror",

--- a/metrics/perf_monitor/Cargo.toml
+++ b/metrics/perf_monitor/Cargo.toml
@@ -16,4 +16,3 @@ thiserror.workspace = true
 workflow-perf-monitor = { version = "0.0.1" }
 tokio = { workspace = true, features = ["rt", "macros", "time"] }
 portable-atomic = {version = "1.4.1", features = ["float"]}
-page_size = "0.5.0"

--- a/metrics/perf_monitor/src/builder.rs
+++ b/metrics/perf_monitor/src/builder.rs
@@ -8,7 +8,6 @@ pub struct Builder<TS, D, CB> {
     tick_service: TS,
     fetch_interval: D,
     fetch_callback: CB,
-    page_size: usize,
 }
 
 impl Builder<Unspecified, Unspecified, Unspecified> {
@@ -19,24 +18,19 @@ impl Builder<Unspecified, Unspecified, Unspecified> {
 
 impl Default for Builder<Unspecified, Unspecified, Unspecified> {
     fn default() -> Self {
-        Self {
-            tick_service: Unspecified {},
-            fetch_interval: Unspecified {},
-            fetch_callback: Unspecified {},
-            page_size: page_size::get(),
-        }
+        Self { tick_service: Unspecified {}, fetch_interval: Unspecified {}, fetch_callback: Unspecified {} }
     }
 }
 
 impl<D, CB> Builder<Unspecified, D, CB> {
     pub fn with_tick_service<TS: AsRef<TickService>>(self, tick_service: TS) -> Builder<TS, D, CB> {
-        Builder { tick_service, fetch_interval: self.fetch_interval, fetch_callback: self.fetch_callback, page_size: self.page_size }
+        Builder { tick_service, fetch_interval: self.fetch_interval, fetch_callback: self.fetch_callback }
     }
 }
 
 impl<TS, CB> Builder<TS, Unspecified, CB> {
     pub fn with_fetch_interval(self, fetch_interval: Duration) -> Builder<TS, Duration, CB> {
-        Builder { tick_service: self.tick_service, fetch_interval, fetch_callback: self.fetch_callback, page_size: self.page_size }
+        Builder { tick_service: self.tick_service, fetch_interval, fetch_callback: self.fetch_callback }
     }
 }
 
@@ -45,12 +39,7 @@ impl<TS, D> Builder<TS, D, Unspecified> {
         self,
         fetch_callback: CB,
     ) -> Builder<TS, D, Box<dyn Fn(CountersSnapshot) + Sync + Send>> {
-        Builder {
-            tick_service: self.tick_service,
-            fetch_interval: self.fetch_interval,
-            fetch_callback: Box::new(fetch_callback) as _,
-            page_size: self.page_size,
-        }
+        Builder { tick_service: self.tick_service, fetch_interval: self.fetch_interval, fetch_callback: Box::new(fetch_callback) as _ }
     }
 }
 
@@ -61,7 +50,6 @@ impl<TS: AsRef<TickService>> Builder<TS, Unspecified, Unspecified> {
             fetch_interval: Duration::from_secs(1),
             counters: Default::default(),
             fetch_callback: None,
-            page_size: self.page_size as u64,
         }
     }
 }
@@ -73,7 +61,6 @@ impl<TS: AsRef<TickService>> Builder<TS, Duration, Unspecified> {
             fetch_interval: self.fetch_interval,
             counters: Default::default(),
             fetch_callback: None,
-            page_size: self.page_size as u64,
         }
     }
 }
@@ -85,7 +72,6 @@ impl<TS: AsRef<TickService>> Builder<TS, Unspecified, Box<dyn Fn(CountersSnapsho
             fetch_interval: Duration::from_secs(1),
             counters: Default::default(),
             fetch_callback: Some(self.fetch_callback),
-            page_size: self.page_size as u64,
         }
     }
 }
@@ -97,7 +83,6 @@ impl<TS: AsRef<TickService>> Builder<TS, Duration, Box<dyn Fn(CountersSnapshot) 
             fetch_interval: self.fetch_interval,
             counters: Default::default(),
             fetch_callback: Some(self.fetch_callback),
-            page_size: self.page_size as u64,
         }
     }
 }

--- a/metrics/perf_monitor/src/counters.rs
+++ b/metrics/perf_monitor/src/counters.rs
@@ -16,9 +16,6 @@ pub(crate) struct Counters {
     /// Usage" "VM Size" column of taskmgr.exe.
     pub virtual_memory_size: AtomicU64,
 
-    pub resident_set_size_bytes: AtomicU64,
-    pub virtual_memory_size_bytes: AtomicU64,
-
     pub core_num: AtomicUsize,
     pub cpu_usage: AtomicF64,
 
@@ -34,8 +31,6 @@ impl Counters {
     pub(crate) fn update(&self, snapshot: CountersSnapshot) {
         self.resident_set_size.store(snapshot.resident_set_size, Ordering::Release);
         self.virtual_memory_size.store(snapshot.resident_set_size, Ordering::Release);
-        self.resident_set_size_bytes.store(snapshot.resident_set_size_bytes, Ordering::Release);
-        self.virtual_memory_size_bytes.store(snapshot.virtual_memory_size_bytes, Ordering::Release);
         self.core_num.store(snapshot.core_num, Ordering::Release);
         self.cpu_usage.store(snapshot.cpu_usage, Ordering::Release);
         self.fd_num.store(snapshot.fd_num, Ordering::Release);
@@ -48,8 +43,6 @@ impl Counters {
         CountersSnapshot {
             resident_set_size: self.resident_set_size.load(Ordering::Acquire),
             virtual_memory_size: self.virtual_memory_size.load(Ordering::Acquire),
-            resident_set_size_bytes: self.resident_set_size_bytes.load(Ordering::Acquire),
-            virtual_memory_size_bytes: self.virtual_memory_size_bytes.load(Ordering::Acquire),
             core_num: self.core_num.load(Ordering::Acquire),
             cpu_usage: self.cpu_usage.load(Ordering::Acquire),
             fd_num: self.fd_num.load(Ordering::Acquire),
@@ -75,9 +68,6 @@ pub struct CountersSnapshot {
     /// On Windows this is an alias for pagefile field and it matches "Mem
     /// Usage" "VM Size" column of taskmgr.exe.
     pub virtual_memory_size: u64,
-
-    pub resident_set_size_bytes: u64,
-    pub virtual_memory_size_bytes: u64,
 
     pub core_num: usize,
     pub cpu_usage: f64,

--- a/metrics/perf_monitor/src/lib.rs
+++ b/metrics/perf_monitor/src/lib.rs
@@ -29,7 +29,6 @@ pub struct Monitor<TS: AsRef<TickService>> {
     fetch_interval: Duration,
     counters: Counters,
     fetch_callback: Option<Box<dyn Fn(CountersSnapshot) + Sync + Send>>,
-    page_size: u64,
 }
 
 impl<TS: AsRef<TickService>> Monitor<TS> {
@@ -60,8 +59,6 @@ impl<TS: AsRef<TickService>> Monitor<TS> {
             let counters_snapshot = CountersSnapshot {
                 resident_set_size,
                 virtual_memory_size,
-                resident_set_size_bytes: resident_set_size * self.page_size,
-                virtual_memory_size_bytes: virtual_memory_size * self.page_size,
                 core_num,
                 cpu_usage,
                 fd_num,

--- a/rpc/core/src/model/message.rs
+++ b/rpc/core/src/model/message.rs
@@ -688,8 +688,8 @@ pub struct GetMetricsRequest {
 #[derive(Default, Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, BorshSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ProcessMetrics {
-    pub resident_set_size_bytes: u64,
-    pub virtual_memory_size_bytes: u64,
+    pub resident_set_size: u64,
+    pub virtual_memory_size: u64,
     pub core_num: u64,
     pub cpu_usage: f64,
     pub fd_num: u64,

--- a/rpc/service/src/service.rs
+++ b/rpc/service/src/service.rs
@@ -641,8 +641,8 @@ impl RpcApi for RpcCoreService {
 
     async fn get_metrics_call(&self, req: GetMetricsRequest) -> RpcResult<GetMetricsResponse> {
         let CountersSnapshot {
-            resident_set_size_bytes,
-            virtual_memory_size_bytes,
+            resident_set_size,
+            virtual_memory_size,
             core_num,
             cpu_usage,
             fd_num,
@@ -653,8 +653,8 @@ impl RpcApi for RpcCoreService {
             ..
         } = self.perf_monitor.snapshot();
         let process_metrics = req.process_metrics.then_some(ProcessMetrics {
-            resident_set_size_bytes,
-            virtual_memory_size_bytes,
+            resident_set_size,
+            virtual_memory_size,
             core_num: core_num as u64,
             cpu_usage,
             fd_num: fd_num as u64,


### PR DESCRIPTION
The "page_size" attribute and its related attributes "resident_set_size_bytes" and "virutal_memory_size_bytes" have been removed from the performance monitor (perf_monitor) module. These counters were found to be unnecessary and their removal improves the simplicity and readability of the module. This change has also led to the removal of the "page_size" package from the dependencies.