### PR TITLE
Refactor scripts to use parse args and bail node not synced

### DIFF
--- a/wasm/nodejs/refactoring/addresses.js
+++ b/wasm/nodejs/refactoring/addresses.js
@@ -1,20 +1,18 @@
 globalThis.WebSocket = require('websocket').w3cwebsocket;
 
 const kaspa = require('../kaspa/kaspa_wasm');
+const {parseArgs} = require("../utils");
 const {
-    RpcClient,
-    Encoding,
     XPublicKey,
     createAddress,
     NetworkType,
 } = kaspa;
 kaspa.init_console_panic_hook();
 
-(async ()=>{
+(async () => {
+    const {} = parseArgs();
 
-
-
-    let xpub = await XPublicKey.fromMasterXPrv(
+    const xpub = await XPublicKey.fromMasterXPrv(
         "kprv5y2qurMHCsXYrNfU3GCihuwG3vMqFji7PZXajMEqyBkNh9UZUJgoHYBLTKu1eM4MvUtomcXPQ3Sw9HZ5ebbM4byoUciHo1zrPJBQfqpLorQ",
         false,
         0n
@@ -24,12 +22,11 @@ kaspa.init_console_panic_hook();
 
     let keys = await xpub.receivePubkeys(0, 10);
     console.log("receive address  keys", keys);
-    let addresses = keys.map(key=>createAddress(key, NetworkType.Mainnet).toString());
+    let addresses = keys.map(key => createAddress(key, NetworkType.Mainnet).toString());
     console.log("receive addresses", addresses);
 
     keys = await xpub.changePubkeys(0, 10);
     console.log("change address keys", keys)
-    addresses = keys.map(key=>createAddress(key, NetworkType.Mainnet).toString());
+    addresses = keys.map(key => createAddress(key, NetworkType.Mainnet).toString());
     console.log("change addresses", addresses);
-
 })();

--- a/wasm/nodejs/refactoring/addresses.js
+++ b/wasm/nodejs/refactoring/addresses.js
@@ -1,7 +1,7 @@
 globalThis.WebSocket = require('websocket').w3cwebsocket;
 
-let kaspa = require('./kaspa/kaspa_wasm');
-let {
+const kaspa = require('../kaspa/kaspa_wasm');
+const {
     RpcClient,
     Encoding,
     XPublicKey,
@@ -11,7 +11,9 @@ let {
 kaspa.init_console_panic_hook();
 
 (async ()=>{
-    
+
+
+
     let xpub = await XPublicKey.fromMasterXPrv(
         "kprv5y2qurMHCsXYrNfU3GCihuwG3vMqFji7PZXajMEqyBkNh9UZUJgoHYBLTKu1eM4MvUtomcXPQ3Sw9HZ5ebbM4byoUciHo1zrPJBQfqpLorQ",
         false,

--- a/wasm/nodejs/refactoring/hd-wallet.js
+++ b/wasm/nodejs/refactoring/hd-wallet.js
@@ -1,5 +1,6 @@
-let kaspa = require('./kaspa/kaspa_wasm');
-let {
+const kaspa = require('../kaspa/kaspa_wasm');
+const {parseArgs} = require("../utils");
+const {
     Mnemonic,
     XPrv,
     DerivationPath
@@ -7,38 +8,38 @@ let {
 
 kaspa.init_console_panic_hook();
 
-(async ()=>{
-    let mnemonic1 = Mnemonic.random();
+(async () => {
+    const {} = parseArgs();
+
+    const mnemonic1 = Mnemonic.random();
     console.log("mnemonic1", mnemonic1);
 
-    let mnemonic2 = new Mnemonic(mnemonic1.phrase);
+    const mnemonic2 = new Mnemonic(mnemonic1.phrase);
     console.log("mnemonic2", mnemonic2);
 
-    let seed1 = mnemonic1.toSeed("my_password");
+    const seed1 = mnemonic1.toSeed("my_password");
     console.log("seed1", seed1);
 
-    let seed2 = mnemonic2.toSeed("my_password");
+    const seed2 = mnemonic2.toSeed("my_password");
     console.log("seed2", seed2);
 
-    if (seed1 != seed2){
+    if (seed1 !== seed2) {
         throw Error("mnemonic restore dont works");
     }
 
-    let xPrv = new XPrv(seed1);
+    const xPrv = new XPrv(seed1);
 
     console.log("xPrv", xPrv.intoString("xprv"))
 
     console.log("xPrv", xPrv.derivePath("m/1'/2'/3").intoString("xprv"))
 
-    let path = new DerivationPath("m/1'");
+    const path = new DerivationPath("m/1'");
     path.push(2, true);
     path.push(3, false);
-    console.log("path", path+"");
+    console.log("path", path + "");
 
     console.log("xPrv", xPrv.derivePath(path).intoString("xprv"))
 
-    let xPub = xPrv.publicKey();
-
+    const xPub = xPrv.publicKey();
     console.log("xPub", xPub.derivePath("m/1").intoString("xpub"));
-
 })();

--- a/wasm/nodejs/refactoring/header.js
+++ b/wasm/nodejs/refactoring/header.js
@@ -1,61 +1,58 @@
+const kaspa = require('../kaspa/kaspa_wasm');
+const {parseArgs} = require("../utils");
+kaspa.init_console_panic_hook();
 
-let {
-    Header,
-    init_console_panic_hook
-} = require('./kaspa/kaspa_wasm');
-init_console_panic_hook();
+(async () => {
+    const {} = parseArgs();
 
-(async ()=>{
-    
-    let header = new Header({
+    const header = new kaspa.Header({
         // hash : "8e40af02265360d59f4ecf9ae9ebf8f00a3118408f5a9cdcbcc9c0f93642f3af",
-        hashMerkleRoot : "bbb490cbce5dc392608000d3aa40e2bfb814c415eac7788237f4eb3467b82059",
-        acceptedIdMerkleRoot : "ab7f8fd73cc7f55c3598de5cdd27ef697161879c3edf52488f2ce23054a3e2ed",
-        utxoCommitment : "2c2d36bf20940ae59858af89a5acba841cafaf84722174e9136077d3c79d9a44",
-        pruningPoint : "8e40af02265360d59f4ecf9ae9ebf8f00a3118408f5a9cdcbcc9c0f93642f3af",
+        hashMerkleRoot: "bbb490cbce5dc392608000d3aa40e2bfb814c415eac7788237f4eb3467b82059",
+        acceptedIdMerkleRoot: "ab7f8fd73cc7f55c3598de5cdd27ef697161879c3edf52488f2ce23054a3e2ed",
+        utxoCommitment: "2c2d36bf20940ae59858af89a5acba841cafaf84722174e9136077d3c79d9a44",
+        pruningPoint: "8e40af02265360d59f4ecf9ae9ebf8f00a3118408f5a9cdcbcc9c0f93642f3af",
         timestamp: 1n,
-        version: 1,   
+        version: 1,
         parentsByLevel: [
             ["b4797d2df131d22b2fed8c61b8de2f6cb7b46c303473be4c36499f7ea96b0a5a"],
             ["dbe16955b7c0e56196cdcdcf3a122681871e7aede1f29ad9ea4f640670483cde"]
         ],
-        bits : 23,
+        bits: 23,
         nonce: 567n,
         daaScore: 0n,
         blueScore: 0n,
-        blueWork : "baadf00d",
+        blueWork: "baadf00d",
 
     });
 
     console.log("initial header:", header);
-    let hash = header.finalize();
+    const hash = header.finalize();
     console.log("header (after finalize):", header);
     console.log("resulting hash:", hash);
 
     header.hash = "73fec18005560d4e3654b1c563c6629d48f3a45f42e5ea772e3ad984339f1e19";
 
-    // note that asJSON() returns a JSON string where each BigInt is represented by an integer value, 
+    // note that asJSON() returns a JSON string where each BigInt is represented by an integer value,
     // whereas toJSON() returns a JavaScript object containing BigInt objects.
-    let headerAsJSON = header.asJSON();
+    const headerAsJSON = header.asJSON();
     console.log("header JSON (via asJSON()):", typeof headerAsJSON, headerAsJSON);
-    let headerToJSON = header.toJSON();
+    const headerToJSON = header.toJSON();
     console.log("header JSON (via Serde):", typeof headerToJSON, headerToJSON);
 
-    let header_copy = new Header(header);
+    const header_copy = new kaspa.Header(header);
     header_copy.version = 2;
     header_copy.finalize();
     console.log("header copy:", header_copy);
 
-    // NOTE: that the assignment below has no effect. This is due to `parentsByLevel` being 
+    // NOTE: that the assignment below has no effect. This is due to `parentsByLevel` being
     // accessed via a `getter/setter`.
     header.parentsByLevel[0][0] = "0000000000000000000000000000000000000000000000000000000000000000";
-    console.log("header.parentsByLevel[0][0]:", header.parentsByLevel[0][0]);    
+    console.log("header.parentsByLevel[0][0]:", header.parentsByLevel[0][0]);
 
     // To change this property, you need to update the entire
     // `parentsByLevel` property in the header via re-assignment.
-    let parentsByLevel = header.parentsByLevel;
+    const parentsByLevel = header.parentsByLevel;
     parentsByLevel[0][0] = "0000000000000000000000000000000000000000000000000000000000000000";
     header.parentsByLevel = parentsByLevel;
-    console.log("header.parentsByLevel:", header.parentsByLevel);    
-
+    console.log("header.parentsByLevel:", header.parentsByLevel);
 })();

--- a/wasm/nodejs/refactoring/header.js
+++ b/wasm/nodejs/refactoring/header.js
@@ -22,7 +22,6 @@ kaspa.init_console_panic_hook();
         daaScore: 0n,
         blueScore: 0n,
         blueWork: "baadf00d",
-
     });
 
     console.log("initial header:", header);

--- a/wasm/nodejs/refactoring/state.js
+++ b/wasm/nodejs/refactoring/state.js
@@ -1,23 +1,18 @@
-let kaspa = require('./kaspa/kaspa_wasm');
+const kaspa = require('../kaspa/kaspa_wasm');
+const {parseArgs} = require("../utils");
 kaspa.init_console_panic_hook();
 
-// let v = 0n.toString();
-// console.log("v=",v);
-
-const {
-    Header, State, Hash
-} = kaspa;
-
-(async ()=>{
+(async () => {
+    const {} = parseArgs();
 
     console.log("creating header");
 
-    let blueWork = BigInt("0x"+"a000000000000001" + 
-                                "b000000000000002" + 
-                                "c000000000000003");
-    console.log("blueWork:",blueWork);
-    let header = new Header({
-        version : 0,
+    const blueWork = BigInt("0x" + "a000000000000001" +
+        "b000000000000002" +
+        "c000000000000003");
+    console.log("blueWork:", blueWork);
+    const header = new kaspa.Header({
+        version: 0,
         parentsByLevel: [["0000000000000000000000000000000000000000000000000000000000000000"]],
         hashMerkleRoot: "5510d0c31d6ae3491d6ce8af8e1048c3f287d9c47e4361bd21a9a5fb033a0c1a",
         acceptedIdMerkleRoot: "0000000000000000000000000000000000000000000000000000000000000000",
@@ -31,20 +26,19 @@ const {
         pruningPoint: "0000000000000000000000000000000000000000000000000000000000000000",
     });
 
-    let header_hash = header.finalize();
+    const header_hash = header.finalize();
     console.log("header:", header);
     console.log("header_hash:", header_hash);
     console.log("header.blueWork:", header.blueWork);
     console.log("header.blueWork.toString(16):", header.blueWork.toString(16));
 
     console.log("creating state");
-    let state = new State(header);
-    let nonce = BigInt("0xffffffffffffffff");
+    const state = new kaspa.State(header);
+    const nonce = BigInt("0xffffffffffffffff");
     console.log("nonce:", nonce);
-    let [a, v] = state.checkPow(nonce);
+    const [a, v] = state.checkPow(nonce);
     console.log("state:", state);
     console.log("[a,v]:", a, v);
     console.log("v.toString(16):", v.toString(16));
-
 })();
 

--- a/wasm/nodejs/refactoring/storage.js
+++ b/wasm/nodejs/refactoring/storage.js
@@ -5,11 +5,11 @@ const {parseArgs} = require("../utils");
 kaspa.init_console_panic_hook();
 
 (async () => {
-    const {} = parseArgs();
+    const {networkType} = parseArgs();
 
     const wallet = new kaspa.Wallet({
         resident: true,
-        networkType: kaspa.NetworkType.Mainnet,
+        networkType: networkType,
     });
 
     wallet.events.setHandler((args) => {

--- a/wasm/nodejs/refactoring/storage.js
+++ b/wasm/nodejs/refactoring/storage.js
@@ -1,40 +1,42 @@
 globalThis.WebSocket = require('websocket').w3cwebsocket; // W3C WebSocket module shim
 
-let kaspa = require('./kaspa/kaspa_wasm');
+const kaspa = require('../kaspa/kaspa_wasm');
+const {parseArgs} = require("../utils");
 kaspa.init_console_panic_hook();
 
-(async ()=>{
-    
-    let wallet = new kaspa.Wallet({ 
-        resident : true,
-        networkType : kaspa.NetworkType.Mainnet,
+(async () => {
+    const {} = parseArgs();
+
+    const wallet = new kaspa.Wallet({
+        resident: true,
+        networkType: kaspa.NetworkType.Mainnet,
     });
 
     wallet.events.setHandler((args) => {
-        console.log("multiplexer event: ",args);
+        console.log("multiplexer event: ", args);
     })
 
-    let walletSecret = "secret";
+    const walletSecret = "secret";
 
-    let descriptor = await wallet.createWallet({
+    const descriptor = await wallet.createWallet({
         walletSecret,
     });
 
-    console.log("descriptor:",descriptor);
+    console.log("descriptor:", descriptor);
 
-    let keydata = await wallet.createPrvKeyData({
-        mnemonic : "fade insect feature mobile impose dinosaur brisk congress soul civil spoil cute maximum resemble zoo tower joke era luxury file eager business empower giggle",
+    const keyData = await wallet.createPrvKeyData({
+        mnemonic: "fade insect feature mobile impose dinosaur brisk congress soul civil spoil cute maximum resemble zoo tower joke era luxury file eager business empower giggle",
         walletSecret
     });
 
-    console.log("keydata:",keydata);
+    console.log("keydata:", keyData);
 
-    let account = await wallet.createAccount(keydata.id, {
-        accountKind : kaspa.AccountKind.Bip32,
+    const account = await wallet.createAccount(keyData.id, {
+        accountKind: kaspa.AccountKind.Bip32,
         walletSecret
     });
 
-    console.log("account:",account);
+    console.log("account:", account);
 
     // await wallet.start();
 
@@ -67,30 +69,67 @@ kaspa.init_console_panic_hook();
 
 // WIP
 class Storage {
-    async exists(name) { }
-    async create(ctx,args) { }
-    async open(ctx,args) { }
-    async commit(ctx) {}
-    async close(ctx) {}
+    async exists(name) {
+    }
+
+    async create(ctx, args) {
+    }
+
+    async open(ctx, args) {
+    }
+
+    async commit(ctx) {
+    }
+
+    async close(ctx) {
+    }
+
     // isOpen() {}
     // descriptor() {}
 
-    async getKeyInfoRange(start, stop) {}
-    async loadKeyInfo(ids) {}
-    async loadKeyData(id) {}
-    async storeKeyInfo(data) {}
-    async storeKeyData(data) {}
-    async removeKeyData(ids) {}
+    async getKeyInfoRange(start, stop) {
+    }
 
-    async getAccountRange(start, stop) {}
-    async getAccountCount(id) {}
-    async loadAccounts(ids) {}
-    async storeAccounts(accounts) {}
-    async removeAccounts(ids) {}
+    async loadKeyInfo(ids) {
+    }
 
-    async getTransactonRecordRange(start, stop) {}
-    async loadTransactionRecords(ids) {}
-    async storeTransactionRecords(transaction_records) {}
-    async removeTransactionRecords(ids) {}
+    async loadKeyData(id) {
+    }
+
+    async storeKeyInfo(data) {
+    }
+
+    async storeKeyData(data) {
+    }
+
+    async removeKeyData(ids) {
+    }
+
+    async getAccountRange(start, stop) {
+    }
+
+    async getAccountCount(id) {
+    }
+
+    async loadAccounts(ids) {
+    }
+
+    async storeAccounts(accounts) {
+    }
+
+    async removeAccounts(ids) {
+    }
+
+    async getTransactonRecordRange(start, stop) {
+    }
+
+    async loadTransactionRecords(ids) {
+    }
+
+    async storeTransactionRecords(transaction_records) {
+    }
+
+    async removeTransactionRecords(ids) {
+    }
 
 }

--- a/wasm/nodejs/refactoring/test.js
+++ b/wasm/nodejs/refactoring/test.js
@@ -1,29 +1,27 @@
 globalThis.WebSocket = require('websocket').w3cwebsocket; // W3C WebSocket module shim
 
-let kaspa = require('./kaspa/kaspa_wasm');
-let { 
-    // RpcClient, 
-    // Encoding, 
-} = kaspa;
+const kaspa = require('../kaspa/kaspa_wasm');
+const {parseArgs} = require("../utils");
 kaspa.init_console_panic_hook();
 
-(async ()=>{
-    
-    let iter = kaspa.get_async_iter();
-    console.log("iter ->",iter);
-    for await (let item of iter) {
-        console.log("item ->",item);
+(async () => {
+    const {} = parseArgs();
+
+    const iter = kaspa.get_async_iter();
+    console.log("iter ->", iter);
+    for await (const item of iter) {
+        console.log("item ->", item);
     }
 
     // let URL = "ws://127.0.0.1:17110";
     // let rpc = new RpcClient(Encoding.Borsh,URL);
-    
+
     // console.log(`# connecting to ${URL}`)
     // await rpc.connect();
 
     // let info = await rpc.getBlockDagInfo();
     // console.log("info:", info);
-    
+
     // await rpc.disconnect();
 
 })();

--- a/wasm/nodejs/refactoring/tx-create.js
+++ b/wasm/nodejs/refactoring/tx-create.js
@@ -1,8 +1,10 @@
 globalThis.WebSocket = require('websocket').w3cwebsocket; // W3C WebSocket module shim
 
-let kaspa = require('./kaspa/kaspa_wasm');
-let { RpcClient, UtxoSet, Address, Encoding, UtxoOrdering, 
-    PaymentOutputs, PaymentOutput, 
+const kaspa = require('../kaspa/kaspa_wasm');
+const {parseArgs, guardRpcIsSynced} = require("../utils");
+const {
+    RpcClient, UtxoSet, Address, Encoding, UtxoOrdering,
+    PaymentOutputs, PaymentOutput,
     XPrivateKey,
     TransactionInput,
     Transaction,
@@ -16,13 +18,19 @@ let { RpcClient, UtxoSet, Address, Encoding, UtxoOrdering,
 } = kaspa;
 kaspa.init_console_panic_hook();
 
-(async ()=>{
-    
-    let URL = "ws://127.0.0.1:17110";
-    let rpc = new RpcClient(Encoding.Borsh,URL);
-    
+(async () => {
+    const {
+        encoding,
+        address,
+        networkType,
+    } = parseArgs();
+
+    const URL = "ws://127.0.0.1:17110";
+    const rpc = new RpcClient(encoding, URL);
+
     console.log(`# connecting to ${URL}`)
     await rpc.connect();
+    await guardRpcIsSynced(rpc);
 
     // let res = await rpc.getBlockTemplate({
     //     extraData:[],
@@ -31,37 +39,39 @@ kaspa.init_console_panic_hook();
     // console.log("res", res.block.header.blueWork);
 
     // return
-    
-    let info = await rpc.getInfo();
+
+    const info = await rpc.getInfo();
     console.log("info", info);
-    
-    let addresses = [
-        new Address("kaspatest:qz7ulu4c25dh7fzec9zjyrmlhnkzrg4wmf89q7gzr3gfrsj3uz6xjceef60sd"),
+
+    const addr = new Address(address ?? "kaspatest:qz7ulu4c25dh7fzec9zjyrmlhnkzrg4wmf89q7gzr3gfrsj3uz6xjceef60sd");
+
+    const addresses = [
+        addr,
         //new Address("kaspatest:qz7ulu4c25dh7fzec9zjyrmlhnkzrg4wmf89q7gzr3gfrsj3uz6xjceef60sd")
     ];
 
     console.log("\ngetting UTXOs...", addresses);
-    let utxos_by_address = await rpc.getUtxosByAddresses({ addresses });
+    const utxosByAddress = await rpc.getUtxosByAddresses({addresses});
     //console.log("utxos_by_address", utxos_by_address.entries.slice(0, 2))
-    let utxoSet = UtxoSet.from(utxos_by_address);
+    const utxoSet = UtxoSet.from(utxosByAddress);
 
-    let amount = 1000n;
-    let utxo_selection = await utxoSet.select(amount+100n, UtxoOrdering.AscendingAmount);
+    const amount = 1000n;
+    const utxoSelection = await utxoSet.select(amount + 100n, UtxoOrdering.AscendingAmount);
 
-    console.log("utxo_selection.amount", utxo_selection.amount)
-    console.log("utxo_selection.totalAmount", utxo_selection.totalAmount)
-    let utxos = utxo_selection.utxos;
+    console.log("utxo_selection.amount", utxoSelection.amount)
+    console.log("utxo_selection.totalAmount", utxoSelection.totalAmount)
+    const utxos = utxoSelection.utxos;
     console.log("utxos[0].data.outpoint", utxos[0]?.data.outpoint)
-    console.log("utxos.*.data.outpoint", utxos.map(a=>a.data.outpoint))
-    console.log("utxos.*.data.entry", utxos.map(a=>a.data.entry))
+    console.log("utxos.*.data.outpoint", utxos.map(a => a.data.outpoint))
+    console.log("utxos.*.data.entry", utxos.map(a => a.data.entry))
 
-    let outputItems = [new PaymentOutput(
-        new Address("kaspatest:qz7ulu4c25dh7fzec9zjyrmlhnkzrg4wmf89q7gzr3gfrsj3uz6xjceef60sd"),
+    const outputItems = [new PaymentOutput(
+        addr,
         amount
     )];
 
-    let priorityFee = 0n;
-    let change_address = new Address("kaspatest:qz7ulu4c25dh7fzec9zjyrmlhnkzrg4wmf89q7gzr3gfrsj3uz6xjceef60sd");
+    const priorityFee = 0n;
+    const changeAddress = addr;
     // let change = utxo_selection.totalAmount - amount - priorityFee;
     // if (change > 500){
     //     outputItems.push(new Output(
@@ -70,21 +80,21 @@ kaspa.init_console_panic_hook();
     //     ))
     // }
 
-    let outputs = new PaymentOutputs(outputItems)
-    
-    let utxoEntryList = [];
-    let inputs = utxos.map((utxo, sequence)=>{
+    const outputs = new PaymentOutputs(outputItems)
+
+    const utxoEntryList = [];
+    const inputs = utxos.map((utxo, sequence) => {
         utxoEntryList.push(utxo.data);
-        
+
         return new TransactionInput({
             previousOutpoint: utxo.data.outpoint,
-            signatureScript:[],
+            signatureScript: [],
             sequence,
-            sigOpCount:0
+            sigOpCount: 0
         });
     });
 
-    let utxoEntries = new UtxoEntries(utxoEntryList);
+    const utxoEntries = new UtxoEntries(utxoEntryList);
 
     console.log("inputs", inputs);
     console.log("outputs", outputs);
@@ -110,29 +120,28 @@ kaspa.init_console_panic_hook();
 
     console.log("transaction", transaction)
 
-    let minimumFee = minimumTransactionFee(transaction, NetworkType.Testnet);
+    const minimumFee = minimumTransactionFee(transaction, networkType);
 
     console.log("minimumFee:", minimumFee);
 
-    let xkey = new XPrivateKey(
+    const xKey = new XPrivateKey(
         "kprv5y2qurMHCsXYrNfU3GCihuwG3vMqFji7PZXajMEqyBkNh9UZUJgoHYBLTKu1eM4MvUtomcXPQ3Sw9HZ5ebbM4byoUciHo1zrPJBQfqpLorQ",
         false,
         0n
     );
 
-    let private_key = xkey.receiveKey(0);
-    
+    const private_key = xKey.receiveKey(0);
+
     let mtx = new MutableTransaction(transaction, utxoEntries);
-    let adjustTransactionResult = adjustTransactionForFee(mtx, change_address, priorityFee);
+    const adjustTransactionResult = adjustTransactionForFee(mtx, changeAddress, priorityFee);
     console.log("adjustTransactionResult", adjustTransactionResult)
     mtx = signTransaction(mtx, [private_key], true);
     console.log("before submit mtx.id", mtx.id)
     transaction = mtx.toRpcTransaction();
-    
-    let result = await rpc.submitTransaction({transaction, allowOrphan:false});
+
+    let result = await rpc.submitTransaction({transaction, allowOrphan: false});
 
     console.log("result", result)
 
     await rpc.disconnect();
-
 })();

--- a/wasm/nodejs/refactoring/tx-script-sign.js
+++ b/wasm/nodejs/refactoring/tx-script-sign.js
@@ -17,7 +17,6 @@ kaspa.init_console_panic_hook();
     const {
         encoding,
         address,
-        networkType,
     } = parseArgs();
 
     const URL = "ws://127.0.0.1:17110";

--- a/wasm/nodejs/refactoring/tx-script-sign.js
+++ b/wasm/nodejs/refactoring/tx-script-sign.js
@@ -1,9 +1,10 @@
 globalThis.WebSocket = require('websocket').w3cwebsocket; // W3C WebSocket module shim
 
-// let {RpcClient,Encoding,init_console_panic_hook,defer} = require('./kaspa');
-let kaspa = require('./kaspa/kaspa_wasm');
-let { RpcClient, UtxoSet, Address, Encoding, UtxoOrdering, 
-    PaymentOutputs, PaymentOutput, 
+let kaspa = require('../kaspa/kaspa_wasm');
+const {parseArgs, guardRpcIsSynced} = require("../utils");
+let {
+    RpcClient, UtxoSet, Address, Encoding, UtxoOrdering,
+    PaymentOutputs, PaymentOutput,
     XPrivateKey,
     VirtualTransaction,
     createTransaction,
@@ -12,77 +13,82 @@ let { RpcClient, UtxoSet, Address, Encoding, UtxoOrdering,
 } = kaspa;
 kaspa.init_console_panic_hook();
 
-(async ()=>{
-    // return;
-    
-    let URL = "ws://127.0.0.1:17110";
-    let rpc = new RpcClient(Encoding.Borsh,URL);
-    
+(async () => {
+    const {
+        encoding,
+        address,
+        networkType,
+    } = parseArgs();
+
+    const URL = "ws://127.0.0.1:17110";
+    const rpc = new RpcClient(encoding, URL);
+
     console.log(`# connecting to ${URL}`)
     await rpc.connect();
     console.log(`# connected ...`)
-    
-    let info1 = await rpc.getInfo();
+    await guardRpcIsSynced(rpc);
+
+    const info1 = await rpc.getInfo();
     console.log(info1);
-    let info2 = await rpc.getInfo();
+    const info2 = await rpc.getInfo();
     console.log(info2);
-    
-    let addresses = [
-        new Address("kaspatest:qz7ulu4c25dh7fzec9zjyrmlhnkzrg4wmf89q7gzr3gfrsj3uz6xjceef60sd")
+
+    const addr = new Address(address ?? "kaspatest:qz7ulu4c25dh7fzec9zjyrmlhnkzrg4wmf89q7gzr3gfrsj3uz6xjceef60sd");
+    const addresses = [
+        addr
     ];
 
     console.log("\nJSON.stringify(addresses):", JSON.stringify(addresses));
 
     console.log("\ngetting UTXOs...");
-    let utxos_by_address = await rpc.getUtxosByAddresses({ addresses });
+    const utxosByAddress = await rpc.getUtxosByAddresses({addresses});
     console.log("Creating UtxoSet...");
     //console.log("utxos_by_address", utxos_by_address)
-    let utxoSet = UtxoSet.from(utxos_by_address);
+    const utxoSet = UtxoSet.from(utxosByAddress);
 
     //console.log("utxos_by_address", utxos_by_address)
 
-    let amount = 1000n;
+    const amount = 1000n;
 
-    let utxo_selection = await utxoSet.select(amount+100n, UtxoOrdering.AscendingAmount);
+    const utxoSelection = await utxoSet.select(amount + 100n, UtxoOrdering.AscendingAmount);
 
-    console.log("utxo_selection.amount", utxo_selection.amount)
-    console.log("utxo_selection.totalAmount", utxo_selection.totalAmount)
+    console.log("utxo_selection.amount", utxoSelection.amount)
+    console.log("utxo_selection.totalAmount", utxoSelection.totalAmount)
 
-    let output = new PaymentOutput(
-        new Address("kaspatest:qz7ulu4c25dh7fzec9zjyrmlhnkzrg4wmf89q7gzr3gfrsj3uz6xjceef60sd"),
+    const output = new PaymentOutput(
+        addr,
         amount
     );
     //console.log("output", output)
-    let outputs = new PaymentOutputs([output])
+    const outputs = new PaymentOutputs([output])
 
     console.log("outputs", outputs)
 
-    let change_address = new Address("kaspatest:qz7ulu4c25dh7fzec9zjyrmlhnkzrg4wmf89q7gzr3gfrsj3uz6xjceef60sd");
+    const changeAddress = addr;
 
-    let priorityFee = 1500;
-    let tx = createTransaction(utxo_selection, outputs, change_address, priorityFee);
-    let scriptHashes = tx.getScriptHashes();
+    const priorityFee = 1500;
+    const tx = createTransaction(utxoSelection, outputs, changeAddress, priorityFee);
+    const scriptHashes = tx.getScriptHashes();
     console.log("scriptHashes", scriptHashes)
 
-    let xkey = new XPrivateKey(
+    const xKey = new XPrivateKey(
         "kprv5y2qurMHCsXYrNfU3GCihuwG3vMqFji7PZXajMEqyBkNh9UZUJgoHYBLTKu1eM4MvUtomcXPQ3Sw9HZ5ebbM4byoUciHo1zrPJBQfqpLorQ",
         false,
         0n
     );
 
-    let private_key = xkey.receiveKey(0);
+    const private_key = xKey.receiveKey(0);
 
-    let signatures = scriptHashes.map(hash=>signScriptHash(hash, private_key));
+    const signatures = scriptHashes.map(hash => signScriptHash(hash, private_key));
     console.log("signatures", signatures)
 
-    let transaction = tx.setSignatures(signatures);
+    const transaction = tx.setSignatures(signatures);
     console.log("transaction", transaction)
     //let transaction = tx.toRpcTransaction();
 
-    let result = await rpc.submitTransaction({transaction, allowOrphan:false});
+    const result = await rpc.submitTransaction({transaction, allowOrphan: false});
 
     console.log("result", result)
 
     await rpc.disconnect();
-
 })();

--- a/wasm/nodejs/refactoring/tx-send.js
+++ b/wasm/nodejs/refactoring/tx-send.js
@@ -1,9 +1,10 @@
 globalThis.WebSocket = require('websocket').w3cwebsocket; // W3C WebSocket module shim
 
-// let {RpcClient,Encoding,init_console_panic_hook,defer} = require('./kaspa');
-let kaspa = require('./kaspa/kaspa_wasm');
-let { RpcClient, UtxoSet, Address, Encoding, UtxoOrdering, 
-    PaymentOutputs, PaymentOutput, 
+const kaspa = require('../kaspa/kaspa_wasm');
+const {parseArgs, guardRpcIsSynced} = require("../utils");
+const {
+    RpcClient, UtxoSet, Address, Encoding, UtxoOrdering,
+    PaymentOutputs, PaymentOutput,
     XPrivateKey,
     VirtualTransaction,
     createTransaction,
@@ -14,19 +15,25 @@ let { RpcClient, UtxoSet, Address, Encoding, UtxoOrdering,
 } = kaspa;
 kaspa.init_console_panic_hook();
 
-(async ()=>{
-    
-    let URL = "ws://127.0.0.1:17110";
-    let rpc = new RpcClient(Encoding.Borsh,URL);
-    
+(async () => {
+    const {
+        encoding,
+        address,
+    } = parseArgs();
+
+    const URL = "ws://127.0.0.1:17110";
+    const rpc = new RpcClient(encoding, URL);
+
     console.log(`# connecting to ${URL}`)
     await rpc.connect();
-    
-    let info = await rpc.getInfo();
+    await guardRpcIsSynced(rpc);
+
+    const info = await rpc.getInfo();
     console.log("info", info);
-    
-    let addresses = [
-        new Address("kaspatest:qz7ulu4c25dh7fzec9zjyrmlhnkzrg4wmf89q7gzr3gfrsj3uz6xjceef60sd"),
+
+    const addr = new Address(address ?? "kaspatest:qz7ulu4c25dh7fzec9zjyrmlhnkzrg4wmf89q7gzr3gfrsj3uz6xjceef60sd");
+    const addresses = [
+        addr,
         //new Address("kaspatest:qz7ulu4c25dh7fzec9zjyrmlhnkzrg4wmf89q7gzr3gfrsj3uz6xjceef60sd")
     ];
 
@@ -37,55 +44,54 @@ kaspa.init_console_panic_hook();
     // console.log(addresses.toString());
 
     console.log("\ngetting UTXOs...");
-    let utxos_by_address = await rpc.getUtxosByAddresses({ addresses });
+    const utxosByAddress = await rpc.getUtxosByAddresses({addresses});
     console.log("Creating UtxoSet...");
     //console.log("utxos_by_address", utxos_by_address)
-    let utxoSet = UtxoSet.from(utxos_by_address);
+    const utxoSet = UtxoSet.from(utxosByAddress);
 
     //console.log("utxos_by_address", utxos_by_address)
 
-    let amount = 1000n;
+    const amount = 1000n;
 
-    let utxo_selection = await utxoSet.select(amount+100n, UtxoOrdering.AscendingAmount);
+    const utxoSelection = await utxoSet.select(amount + 100n, UtxoOrdering.AscendingAmount);
 
-    console.log("utxo_selection.amount", utxo_selection.amount)
-    console.log("utxo_selection.totalAmount", utxo_selection.totalAmount)
-    let utxos = utxo_selection.utxos;
+    console.log("utxo_selection.amount", utxoSelection.amount)
+    console.log("utxo_selection.totalAmount", utxoSelection.totalAmount)
+    const utxos = utxoSelection.utxos;
     console.log("utxos", utxos)
-    console.log("utxos.*.data.entry", utxos.map(a=>a.data.entry))
+    console.log("utxos.*.data.entry", utxos.map(a => a.data.entry))
 
 
-    let output = new PaymentOutput(
-        new Address("kaspatest:qz7ulu4c25dh7fzec9zjyrmlhnkzrg4wmf89q7gzr3gfrsj3uz6xjceef60sd"),
+    const output = new PaymentOutput(
+        addr,
         amount
     );
     //console.log("output", output)
-    let outputs = new PaymentOutputs([output])
+    const outputs = new PaymentOutputs([output])
 
     console.log("outputs", outputs)
 
-    let change_address = new Address("kaspatest:qz7ulu4c25dh7fzec9zjyrmlhnkzrg4wmf89q7gzr3gfrsj3uz6xjceef60sd");
+    const changeAddress = addr;
 
-    let priorityFee = 0;
-    let tx = createTransaction(utxo_selection, outputs, change_address, priorityFee);
+    const priorityFee = 0;
+    const tx = createTransaction(utxoSelection, outputs, changeAddress, priorityFee);
     console.log("tx", tx)
 
-    let xkey = new XPrivateKey(
+    const xKey = new XPrivateKey(
         "kprv5y2qurMHCsXYrNfU3GCihuwG3vMqFji7PZXajMEqyBkNh9UZUJgoHYBLTKu1eM4MvUtomcXPQ3Sw9HZ5ebbM4byoUciHo1zrPJBQfqpLorQ",
         false,
         0n
     );
 
-    let private_key = xkey.receiveKey(0);
+    const private_key = xKey.receiveKey(0);
 
     console.log("tx.inputs", tx.inputs)
 
     let transaction = signTransaction(tx, [private_key], true);
     transaction = transaction.toRpcTransaction();
-    let result = await rpc.submitTransaction({transaction, allowOrphan:false});
+    const result = await rpc.submitTransaction({transaction, allowOrphan: false});
 
     console.log("result", result)
 
     await rpc.disconnect();
-
 })();

--- a/wasm/nodejs/rpc.js
+++ b/wasm/nodejs/rpc.js
@@ -1,20 +1,24 @@
 globalThis.WebSocket = require('websocket').w3cwebsocket; // W3C WebSocket module shim
 
-let kaspa = require('./kaspa/kaspa_wasm');
-let { RpcClient, 
-    Encoding, NetworkType
+const kaspa = require('./kaspa/kaspa_wasm');
+const {parseArgs} = require("./utils");
+const {
+    RpcClient
 } = kaspa;
 kaspa.init_console_panic_hook();
 
-(async ()=>{
-    
-    let rpc = new RpcClient(Encoding.Borsh,"127.0.0.1", NetworkType.Testnet);
+(async () => {
+    const {
+        networkType,
+        encoding,
+    } = parseArgs();
+
+    const rpc = new RpcClient(encoding, "127.0.0.1", networkType);
     console.log(`# connecting to ${rpc.url}`)
     await rpc.connect();
 
-    let info = await rpc.getBlockDagInfo();
+    const info = await rpc.getBlockDagInfo();
     console.log("info:", info);
-    
-    await rpc.disconnect();
 
+    await rpc.disconnect();
 })();

--- a/wasm/nodejs/simple-transaction.js
+++ b/wasm/nodejs/simple-transaction.js
@@ -12,7 +12,7 @@ const {
     createTransactions,
     init_console_panic_hook
 } = require('./kaspa/kaspa_wasm');
-const {parseArgs} = require('./utils');
+const {parseArgs, guardRpcIsSynced} = require('./utils');
 
 init_console_panic_hook();
 
@@ -42,6 +42,7 @@ async function runDemo() {
     console.log(`Connecting to ${rpc.url}`);
 
     await rpc.connect();
+    await guardRpcIsSynced(rpc);
 
     let entries = await rpc.getUtxosByAddresses([skAddress]);
 

--- a/wasm/nodejs/utils.js
+++ b/wasm/nodejs/utils.js
@@ -61,6 +61,20 @@ function parseArgs(options = {
     };
 }
 
+async function guardRpcIsSynced(rpc) {
+    try {
+        const info = await rpc.getInfo();
+        if (!info.isSynced) {
+            console.error(`RPC is not synced, please wait until it is synced and try again.`);
+            process.exit(0);
+        }
+    } catch (err) {
+        console.error(`Failed to get info from RPC: ${err.message}`);
+        process.exit(1);
+    }
+}
+
 module.exports = {
     parseArgs,
+    guardRpcIsSynced,
 };


### PR DESCRIPTION
- Refactored all scripts to use parseArgs to dynamically determine the address, encoding and/or network type and use these instead of the hardcoded values with fallback to the previous hardcoded values.
- Add a guard to check whether the node is synced after connecting to the RPC, and bailing otherwise.
- Refactored names to follow camelCase and prefer `const` instead of `let` whenever variables are immutable.