### PR TITLE
Js api rpc client and easier address

### DIFF
--- a/wasm/nodejs/demo.js
+++ b/wasm/nodejs/demo.js
@@ -11,39 +11,50 @@ const {
     signTransaction,
     init_console_panic_hook
 } = require('./kaspa/kaspa_wasm');
+const {parseArgs} = require("./utils");
 
 init_console_panic_hook();
 
 async function runDemo() {
-    // From BIP0340
+    const args = parseArgs({});
+
+    // Either NetworkType.Mainnet or NetworkType.Testnet
+    const networkType = args.networkType;
+    // Either Encoding.Borsh or Encoding.SerdeJson
+    const encoding = args.encoding;
+
+    // Create secret key from BIP0340
     const sk = new PrivateKey('b99d75736a0fd0ae2da658959813d680474f5a740a9c970a7da867141596178f');
+    const keypair = sk.toKeypair();
 
-    const kaspaAddress = sk.toKeypair().toAddress(NetworkType.Mainnet).toString();
-    // Full kaspa address: kaspa:qr0lr4ml9fn3chekrqmjdkergxl93l4wrk3dankcgvjq776s9wn9jkdskewva
-    console.info(`Full kaspa address: ${kaspaAddress}`);
+    // For example dff1d77f2a671c5f36183726db2341be58feae1da2deced843240f7b502ba659
+    console.info(keypair.xOnlyPublicKey);
+    // For example 02dff1d77f2a671c5f36183726db2341be58feae1da2deced843240f7b502ba659
+    console.info(keypair.publicKey);
 
-    const addr = new Address(kaspaAddress);
-    console.info(addr);
+    // An address such as kaspa:qr0lr4ml9fn3chekrqmjdkergxl93l4wrk3dankcgvjq776s9wn9jkdskewva
+    const address = keypair.toAddress(networkType);
+    console.info(`Full kaspa address: ${address}`);
+    console.info(address);
 
-    console.info(sk.toKeypair().xOnlyPublicKey); // dff1d77f2a671c5f36183726db2341be58feae1da2deced843240f7b502ba659
-    console.info(sk.toKeypair().publicKey);      // 02dff1d77f2a671c5f36183726db2341be58feae1da2deced843240f7b502ba659
-
-    const rpcUrl = "ws://127.0.0.1:17110";
-    const rpc = new RpcClient(Encoding.Borsh, rpcUrl);
+    const rpcHost = "127.0.0.1";
+    // Parse the url to automatically determine the port for the given host
+    const rpcUrl = RpcClient.parseUrl(rpcHost, encoding, networkType);
+    const rpc = new RpcClient(encoding, rpcUrl, networkType);
 
     await rpc.connect();
 
     try {
-        const utxos = await rpc.getUtxosByAddresses({ addresses: [addr.toString()] });
+        const utxos = await rpc.getUtxosByAddresses({addresses: [address]});
 
         console.info(utxos);
 
         if (utxos.length === 0) {
-            console.info('Send some kaspa to', kaspaAddress, 'before proceeding with the demo');
+            console.info('Send some kaspa to', address, 'before proceeding with the demo');
             return;
         }
 
-        
+
         let total = utxos.reduce((agg, curr) => {
             return curr.utxoEntry.amount + agg;
         }, 0n);
@@ -51,15 +62,15 @@ async function runDemo() {
         console.info('Amount sending', total - BigInt(utxos.length) * 2000n)
 
         const outputs = [{
-            address: addr.toString(),
+            address,
             amount: total - BigInt(utxos.length) * 2000n,
         }];
 
-        const changeAddress = new Address(kaspaAddress);
+        const changeAddress = address;
         console.info(changeAddress);
         const tx = createTransaction(utxos, outputs, changeAddress, 0n, 0, 1, 1);
 
-        console.info(tx)
+        console.info(tx);
 
         let transaction = signTransaction(tx, [sk], true);
 
@@ -67,7 +78,7 @@ async function runDemo() {
 
         console.info(JSON.stringify(rpcTransaction, null, 4));
 
-        let result = await rpc.submitTransaction({transaction: rpcTransaction, allowOrphan:false});
+        let result = await rpc.submitTransaction({transaction: rpcTransaction, allowOrphan: false});
 
         console.info(result);
     } finally {

--- a/wasm/nodejs/refactoring/tx-create.js
+++ b/wasm/nodejs/refactoring/tx-create.js
@@ -26,6 +26,7 @@ kaspa.init_console_panic_hook();
     } = parseArgs();
 
     const rpcHost = "127.0.0.1";
+    // Parse the url to automatically determine the port for the given host
     const rpcUrl = RpcClient.parseUrl(rpcHost, encoding, networkType);
     const rpc = new RpcClient(encoding, rpcUrl, networkType);
 

--- a/wasm/nodejs/refactoring/tx-create.js
+++ b/wasm/nodejs/refactoring/tx-create.js
@@ -25,8 +25,9 @@ kaspa.init_console_panic_hook();
         networkType,
     } = parseArgs();
 
-    const URL = "ws://127.0.0.1:17110";
-    const rpc = new RpcClient(encoding, URL);
+    const rpcHost = "127.0.0.1";
+    const rpcUrl = RpcClient.parseUrl(rpcHost, encoding, networkType);
+    const rpc = new RpcClient(encoding, rpcUrl, networkType);
 
     console.log(`# connecting to ${URL}`)
     await rpc.connect();
@@ -43,7 +44,7 @@ kaspa.init_console_panic_hook();
     const info = await rpc.getInfo();
     console.log("info", info);
 
-    const addr = new Address(address ?? "kaspatest:qz7ulu4c25dh7fzec9zjyrmlhnkzrg4wmf89q7gzr3gfrsj3uz6xjceef60sd");
+    const addr = address ?? "kaspatest:qz7ulu4c25dh7fzec9zjyrmlhnkzrg4wmf89q7gzr3gfrsj3uz6xjceef60sd";
 
     const addresses = [
         addr,
@@ -51,24 +52,19 @@ kaspa.init_console_panic_hook();
     ];
 
     console.log("\ngetting UTXOs...", addresses);
-    const utxosByAddress = await rpc.getUtxosByAddresses({addresses});
-    //console.log("utxos_by_address", utxos_by_address.entries.slice(0, 2))
-    const utxoSet = UtxoSet.from(utxosByAddress);
+    // const utxosByAddress = await rpc.getUtxosByAddresses({addresses});
+
+    const utxos = await rpc.getUtxosByAddresses({ addresses });
 
     const amount = 1000n;
-    const utxoSelection = await utxoSet.select(amount + 100n, UtxoOrdering.AscendingAmount);
-
-    console.log("utxo_selection.amount", utxoSelection.amount)
-    console.log("utxo_selection.totalAmount", utxoSelection.totalAmount)
-    const utxos = utxoSelection.utxos;
-    console.log("utxos[0].data.outpoint", utxos[0]?.data.outpoint)
-    console.log("utxos.*.data.outpoint", utxos.map(a => a.data.outpoint))
-    console.log("utxos.*.data.entry", utxos.map(a => a.data.entry))
-
-    const outputItems = [new PaymentOutput(
-        addr,
-        amount
-    )];
+    // const utxoSelection = await utxoSet.select(amount + 100n, UtxoOrdering.AscendingAmount);
+    //
+    // console.log("utxo_selection.amount", utxoSelection.amount)
+    // console.log("utxo_selection.totalAmount", utxoSelection.totalAmount)
+    // // const utxos = utxoSelection.utxos;
+    // console.log("utxos[0].data.outpoint", utxos[0]?.data.outpoint)
+    // console.log("utxos.*.data.outpoint", utxos.map(a => a.data.outpoint))
+    // console.log("utxos.*.data.entry", utxos.map(a => a.data.entry))
 
     const priorityFee = 0n;
     const changeAddress = addr;
@@ -80,7 +76,12 @@ kaspa.init_console_panic_hook();
     //     ))
     // }
 
-    const outputs = new PaymentOutputs(outputItems)
+    const outputs = [
+        [
+            addr,
+            amount
+        ]
+    ];
 
     const utxoEntryList = [];
     const inputs = utxos.map((utxo, sequence) => {

--- a/wasm/nodejs/refactoring/tx-script-sign.js
+++ b/wasm/nodejs/refactoring/tx-script-sign.js
@@ -14,13 +14,19 @@ let {
 kaspa.init_console_panic_hook();
 
 (async () => {
-    const {
-        encoding,
-        address,
-    } = parseArgs();
+    const args = parseArgs({});
 
-    const URL = "ws://127.0.0.1:17110";
-    const rpc = new RpcClient(encoding, URL);
+    // Either NetworkType.Mainnet or NetworkType.Testnet
+    const networkType = args.networkType;
+    // Either Encoding.Borsh or Encoding.SerdeJson
+    const encoding = args.encoding;
+    // The kaspa address that was passed as an argument or a default one
+    const address = args.address ?? "kaspatest:qz7ulu4c25dh7fzec9zjyrmlhnkzrg4wmf89q7gzr3gfrsj3uz6xjceef60sd";
+
+    const rpcHost = "127.0.0.1";
+    // Parse the url to automatically determine the port for the given host
+    const rpcUrl = RpcClient.parseUrl(rpcHost, encoding, networkType);
+    const rpc = new RpcClient(encoding, rpcUrl, networkType);
 
     console.log(`# connecting to ${URL}`)
     await rpc.connect();
@@ -32,10 +38,7 @@ kaspa.init_console_panic_hook();
     const info2 = await rpc.getInfo();
     console.log(info2);
 
-    const addr = new Address(address ?? "kaspatest:qz7ulu4c25dh7fzec9zjyrmlhnkzrg4wmf89q7gzr3gfrsj3uz6xjceef60sd");
-    const addresses = [
-        addr
-    ];
+    const addresses = [address];
 
     console.log("\nJSON.stringify(addresses):", JSON.stringify(addresses));
 
@@ -54,12 +57,12 @@ kaspa.init_console_panic_hook();
     console.log("utxo_selection.amount", utxoSelection.amount)
     console.log("utxo_selection.totalAmount", utxoSelection.totalAmount)
 
-    const output = new PaymentOutput(
-        addr,
-        amount
-    );
-    //console.log("output", output)
-    const outputs = new PaymentOutputs([output])
+    const outputs = [
+        [
+            address,
+            amount
+        ]
+    ];
 
     console.log("outputs", outputs)
 

--- a/wasm/nodejs/refactoring/tx-send.js
+++ b/wasm/nodejs/refactoring/tx-send.js
@@ -16,13 +16,19 @@ const {
 kaspa.init_console_panic_hook();
 
 (async () => {
-    const {
-        encoding,
-        address,
-    } = parseArgs();
+    const args = parseArgs({});
 
-    const URL = "ws://127.0.0.1:17110";
-    const rpc = new RpcClient(encoding, URL);
+    // Either NetworkType.Mainnet or NetworkType.Testnet
+    const networkType = args.networkType;
+    // Either Encoding.Borsh or Encoding.SerdeJson
+    const encoding = args.encoding;
+    // The kaspa address that was passed as an argument or a default one
+    const address = args.address ?? "kaspatest:qz7ulu4c25dh7fzec9zjyrmlhnkzrg4wmf89q7gzr3gfrsj3uz6xjceef60sd";
+
+    const rpcHost = "127.0.0.1";
+    // Parse the url to automatically determine the port for the given host
+    const rpcUrl = RpcClient.parseUrl(rpcHost, encoding, networkType);
+    const rpc = new RpcClient(encoding, rpcUrl, networkType);
 
     console.log(`# connecting to ${URL}`)
     await rpc.connect();
@@ -31,9 +37,8 @@ kaspa.init_console_panic_hook();
     const info = await rpc.getInfo();
     console.log("info", info);
 
-    const addr = new Address(address ?? "kaspatest:qz7ulu4c25dh7fzec9zjyrmlhnkzrg4wmf89q7gzr3gfrsj3uz6xjceef60sd");
     const addresses = [
-        addr,
+        address,
         //new Address("kaspatest:qz7ulu4c25dh7fzec9zjyrmlhnkzrg4wmf89q7gzr3gfrsj3uz6xjceef60sd")
     ];
 
@@ -62,16 +67,16 @@ kaspa.init_console_panic_hook();
     console.log("utxos.*.data.entry", utxos.map(a => a.data.entry))
 
 
-    const output = new PaymentOutput(
-        addr,
-        amount
-    );
-    //console.log("output", output)
-    const outputs = new PaymentOutputs([output])
+    const outputs = [
+        [
+            address,
+            amount,
+        ]
+    ];
 
     console.log("outputs", outputs)
 
-    const changeAddress = addr;
+    const changeAddress = address;
 
     const priorityFee = 0;
     const tx = createTransaction(utxoSelection, outputs, changeAddress, priorityFee);

--- a/wasm/nodejs/refactoring/utxo-split.js
+++ b/wasm/nodejs/refactoring/utxo-split.js
@@ -33,7 +33,7 @@ kaspa.init_console_panic_hook();
         },
         additionalHelpOutput: '[--address2 <address>]'
     });
-    const address2Arg = args.tokens.find((token) => token.name === 'address2')?.value ?? null;
+    const address2Arg = args.tokens.find((token) => token.name === 'address2')?.value;
 
     // Either NetworkType.Mainnet or NetworkType.Testnet
     const networkType = args.networkType;

--- a/wasm/nodejs/refactoring/utxo-split.js
+++ b/wasm/nodejs/refactoring/utxo-split.js
@@ -77,14 +77,9 @@ kaspa.init_console_panic_hook();
 
     let outputs = [];
     for (let i = 0; i < count; i++) {
-        const output = new PaymentOutput(
-            addr1,
-            amount
-        );
-        outputs.push(output)
+        outputs.push([addr1, amount]);
     }
     const priorityFee = 0n;
-    outputs = new PaymentOutputs(outputs)
 
     //console.log("outputs", outputs)
 

--- a/wasm/nodejs/refactoring/utxo-split.js
+++ b/wasm/nodejs/refactoring/utxo-split.js
@@ -25,13 +25,25 @@ const {
 kaspa.init_console_panic_hook();
 
 (async () => {
-    const {
-        encoding,
-        address,
-    } = parseArgs();
+    const args = parseArgs({
+        additionalParseArgs: {
+            address2: {
+                type: 'string',
+            },
+        },
+        additionalHelpOutput: '[--address2 <address>]'
+    });
+    const address2Arg = args.tokens.find((token) => token.name === 'address2')?.value ?? null;
 
-    const URL = "ws://127.0.0.1:17110";
-    const rpc = new RpcClient(encoding, URL);
+    // Either NetworkType.Mainnet or NetworkType.Testnet
+    const networkType = args.networkType;
+    // Either Encoding.Borsh or Encoding.SerdeJson
+    const encoding = args.encoding;
+
+    const rpcHost = "127.0.0.1";
+    // Parse the url to automatically determine the port for the given host
+    const rpcUrl = RpcClient.parseUrl(rpcHost, encoding, networkType);
+    const rpc = new RpcClient(encoding, rpcUrl, networkType);
 
     console.log(`# connecting to ${URL}`)
     await rpc.connect();
@@ -40,8 +52,8 @@ kaspa.init_console_panic_hook();
     const info = await rpc.getInfo();
     console.log("info", info);
 
-    const addr1 = new Address(address ?? "kaspa:qq5dawejjdzp22jsgtn2mdr3lg45j7pq0yaq8he8t8269lvg87cuwl7ze7djh");
-    const addr2 = new Address("kaspa:qzewpzt0rx6jmvy0eea82lpnf0t7f7frmqavqcaawmt4wk70puazcp8zljgx5");
+    const addr1 = args.address ?? "kaspa:qq5dawejjdzp22jsgtn2mdr3lg45j7pq0yaq8he8t8269lvg87cuwl7ze7djh";
+    const addr2 = address2Arg ?? "kaspa:qzewpzt0rx6jmvy0eea82lpnf0t7f7frmqavqcaawmt4wk70puazcp8zljgx5";
     const addresses = [
         addr1,
         addr2,

--- a/wasm/nodejs/utils.js
+++ b/wasm/nodejs/utils.js
@@ -8,6 +8,11 @@ const {
     NetworkType,
 } = require('./kaspa/kaspa_wasm');
 
+/**
+ * Helper function to parse command line arguments for running the scripts
+ * @param options Additional options to configure the parsing, such as additional arguments for the script and additional help output to go with it
+ * @returns {{address: Address, tokens: NodeUtilParseArgsToken[], networkType: (NetworkType), encoding: (Encoding)}}
+ */
 function parseArgs(options = {
     additionalParseArgs: {},
     additionalHelpOutput: '',

--- a/wasm/nodejs/utils.js
+++ b/wasm/nodejs/utils.js
@@ -41,7 +41,7 @@ function parseArgs(options = {
         }, tokens: true, allowPositionals: true
     });
     if (values.help) {
-        console.log(`Usage: node ${script} [address] [mainnet|testnet] [--address ADDRESS] [--network mainnet|testnet] [--json] ${options.additionalHelpOutput}`);
+        console.log(`Usage: node ${script} [address] [mainnet|testnet] [--address <address>] [--network <mainnet|testnet>] [--json] ${options.additionalHelpOutput}`);
         process.exit(0);
     }
 


### PR DESCRIPTION
- Use the `parseUrl` function for when creating the rpc client to automatically determine the correct port for the encoding and network type being used
- Directly use addresses and payment outputs using simple JavaScript constructs (strings/arrays) when using them in an API without new-ing them up to explicit types first