### PR TITLE
Elertan/enhance parse url

### DIFF
--- a/rpc/wrpc/client/src/client.rs
+++ b/rpc/wrpc/client/src/client.rs
@@ -289,7 +289,7 @@ impl KaspaRpcClient {
         };
 
         let parse_output = parse_host(&url).map_err(|err| Error::Custom(err.to_string()))?;
-        let scheme = parse_output.scheme.ok_or_else(|| {
+        let scheme = parse_output.scheme.map(Ok).unwrap_or_else(|| {
             if !application_runtime::is_web() {
                 return Ok("ws");
             }

--- a/rpc/wrpc/client/src/client.rs
+++ b/rpc/wrpc/client/src/client.rs
@@ -310,37 +310,6 @@ impl KaspaRpcClient {
         });
 
         Ok(Some(format!("{}://{}:{}", scheme, parse_output.host.to_string(), port)))
-        //
-        // let url = if let Some(url) = url {
-        //     if url.starts_with("ws://") || url.starts_with("wss://") || url.starts_with("wrpc://") || url.starts_with("wrpcs://") {
-        //         Some(url)
-        //     } else if application_runtime::is_web() {
-        //         let location = window().location();
-        //         let protocol = location
-        //             .protocol()
-        //             .map_err(|_| Error::AddressError("Unable to obtain window location protocol".to_string()))?
-        //             .replace("http", "ws");
-        //         Some(format!("{protocol}//{url}"))
-        //     } else {
-        //         Some(format!("ws://{url}"))
-        //     }
-        // } else {
-        //     None
-        // };
-        //
-        // let url = url.map(|url| {
-        //     if url.split(':').collect::<Vec<_>>().len() < 3 {
-        //         let port = match encoding {
-        //             WrpcEncoding::Borsh => network_type.default_borsh_rpc_port(),
-        //             WrpcEncoding::SerdeJson => network_type.default_json_rpc_port(),
-        //         };
-        //         format!("{url}:{port}")
-        //     } else {
-        //         url
-        //     }
-        // });
-        //
-        // Ok(url)
     }
 }
 

--- a/rpc/wrpc/client/src/client.rs
+++ b/rpc/wrpc/client/src/client.rs
@@ -1,5 +1,6 @@
 use crate::error::Error;
 use crate::imports::*;
+use crate::parse::parse_host;
 use kaspa_consensus_core::networktype::NetworkType;
 use kaspa_rpc_core::notify::collector::{RpcCoreCollector, RpcCoreConverter};
 pub use kaspa_rpc_macros::build_wrpc_client_interface;
@@ -283,36 +284,63 @@ impl KaspaRpcClient {
     }
 
     pub fn parse_url(url: Option<String>, encoding: Encoding, network_type: NetworkType) -> Result<Option<String>> {
-        let url = if let Some(url) = url {
-            if url.starts_with("ws://") || url.starts_with("wss://") || url.starts_with("wrpc://") || url.starts_with("wrpcs://") {
-                Some(url)
-            } else if application_runtime::is_web() {
-                let location = window().location();
-                let protocol = location
-                    .protocol()
-                    .map_err(|_| Error::AddressError("Unable to obtain window location protocol".to_string()))?
-                    .replace("http", "ws");
-                Some(format!("{protocol}//{url}"))
-            } else {
-                Some(format!("ws://{url}"))
-            }
-        } else {
-            None
+        let Some(url) = url else {
+            return Ok(None);
         };
 
-        let url = url.map(|url| {
-            if url.split(':').collect::<Vec<_>>().len() < 3 {
-                let port = match encoding {
-                    WrpcEncoding::Borsh => network_type.default_borsh_rpc_port(),
-                    WrpcEncoding::SerdeJson => network_type.default_json_rpc_port(),
-                };
-                format!("{url}:{port}")
-            } else {
-                url
+        let parse_output = parse_host(&url).map_err(|err| Error::Custom(err.to_string()))?;
+        let scheme = parse_output.scheme.map(Ok).unwrap_or_else(|| {
+            if !application_runtime::is_web() {
+                return Ok("ws");
             }
+            let location = window().location();
+            let protocol =
+                location.protocol().map_err(|_| Error::AddressError("Unable to obtain window location protocol".to_string()))?;
+            if protocol == "http:" {
+                Ok("ws")
+            } else if protocol == "https:" {
+                Ok("wss")
+            } else {
+                Err(Error::Custom(format!("Unsupported protocol: {}", protocol)))
+            }
+        })?;
+        let port = parse_output.port.unwrap_or_else(|| match encoding {
+            WrpcEncoding::Borsh => network_type.default_borsh_rpc_port(),
+            WrpcEncoding::SerdeJson => network_type.default_json_rpc_port(),
         });
 
-        Ok(url)
+        Ok(Some(format!("{}://{}:{}", scheme, parse_output.host.to_string(), port)))
+        //
+        // let url = if let Some(url) = url {
+        //     if url.starts_with("ws://") || url.starts_with("wss://") || url.starts_with("wrpc://") || url.starts_with("wrpcs://") {
+        //         Some(url)
+        //     } else if application_runtime::is_web() {
+        //         let location = window().location();
+        //         let protocol = location
+        //             .protocol()
+        //             .map_err(|_| Error::AddressError("Unable to obtain window location protocol".to_string()))?
+        //             .replace("http", "ws");
+        //         Some(format!("{protocol}//{url}"))
+        //     } else {
+        //         Some(format!("ws://{url}"))
+        //     }
+        // } else {
+        //     None
+        // };
+        //
+        // let url = url.map(|url| {
+        //     if url.split(':').collect::<Vec<_>>().len() < 3 {
+        //         let port = match encoding {
+        //             WrpcEncoding::Borsh => network_type.default_borsh_rpc_port(),
+        //             WrpcEncoding::SerdeJson => network_type.default_json_rpc_port(),
+        //         };
+        //         format!("{url}:{port}")
+        //     } else {
+        //         url
+        //     }
+        // });
+        //
+        // Ok(url)
     }
 }
 

--- a/rpc/wrpc/client/src/client.rs
+++ b/rpc/wrpc/client/src/client.rs
@@ -289,7 +289,7 @@ impl KaspaRpcClient {
         };
 
         let parse_output = parse_host(&url).map_err(|err| Error::Custom(err.to_string()))?;
-        let scheme = parse_output.scheme.map(Ok).unwrap_or_else(|| {
+        let scheme = parse_output.scheme.ok_or_else(|| {
             if !application_runtime::is_web() {
                 return Ok("ws");
             }

--- a/rpc/wrpc/client/src/lib.rs
+++ b/rpc/wrpc/client/src/lib.rs
@@ -4,3 +4,4 @@ mod imports;
 pub mod result;
 pub mod wasm;
 pub use imports::{KaspaRpcClient, WrpcEncoding};
+pub mod parse;

--- a/rpc/wrpc/client/src/parse.rs
+++ b/rpc/wrpc/client/src/parse.rs
@@ -1,11 +1,25 @@
+use std::fmt::Display;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::num::ParseIntError;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ParseHostOutput<'a> {
-    scheme: Option<&'a str>,
-    host: Host<'a>,
-    port: Option<u16>,
+    pub scheme: Option<&'a str>,
+    pub host: Host<'a>,
+    pub port: Option<u16>,
+}
+
+impl Display for ParseHostOutput<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(scheme) = self.scheme {
+            write!(f, "{}://", scheme)?;
+        }
+        write!(f, "{}", self.host.to_string())?;
+        if let Some(port) = self.port {
+            write!(f, ":{}", port)?;
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -14,6 +28,17 @@ pub enum Host<'a> {
     Hostname(&'a str),
     Ipv4(Ipv4Addr),
     Ipv6(Ipv6Addr),
+}
+
+impl ToString for Host<'_> {
+    fn to_string(&self) -> String {
+        match self {
+            Host::Domain(domain) => domain.to_string(),
+            Host::Hostname(hostname) => hostname.to_string(),
+            Host::Ipv4(ipv4) => ipv4.to_string(),
+            Host::Ipv6(ipv6) => ipv6.to_string(),
+        }
+    }
 }
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]

--- a/rpc/wrpc/client/src/parse.rs
+++ b/rpc/wrpc/client/src/parse.rs
@@ -1,0 +1,184 @@
+use std::net::{Ipv4Addr, Ipv6Addr};
+use std::num::ParseIntError;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ParseHostOutput<'a> {
+    scheme: Option<&'a str>,
+    host: Host<'a>,
+    port: Option<u16>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Host<'a> {
+    Domain(&'a str),
+    Hostname(&'a str),
+    Ipv4(Ipv4Addr),
+    Ipv6(Ipv6Addr),
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ParseHostError {
+    #[error("Invalid input")]
+    InvalidInput,
+    #[error("Invalid port: {0}")]
+    ParsePortError(ParseIntError),
+}
+
+pub fn parse_host(input: &str) -> Result<ParseHostOutput, ParseHostError> {
+    // Attempt to split the input into scheme, host, and port.
+    let (scheme, input) = match input.find("://") {
+        Some(pos) => {
+            let (scheme, input) = input.split_at(pos);
+            (Some(scheme), &input[3..])
+        }
+        None => (None, input),
+    };
+    // Attempt to split path and host.
+    let (input, _path) = match input.find('/') {
+        Some(pos) => input.split_at(pos),
+        None => (input, ""),
+    };
+
+    let (host, port_str) = match input.rfind(':') {
+        Some(pos) => {
+            // Check if char before ':' is also ':'.
+            // As that would mean that the ':' is part of an IPv6 address.
+            if input.chars().nth(pos - 1) == Some(':') {
+                (input, None)
+            } else {
+                let (host, port_str) = input.split_at(pos);
+                (host, Some(&port_str[1..]))
+            }
+        }
+        None => (input, None),
+    };
+
+    if host.is_empty() {
+        return Err(ParseHostError::InvalidInput);
+    }
+
+    let port = port_str
+        .map(|port_str| match port_str.parse::<u16>() {
+            Ok(port) => Ok(port),
+            Err(err) => Err(ParseHostError::ParsePortError(err)),
+        })
+        .map_or(Ok(None), |port| port.map(Some))?;
+
+    // Attempt to parse the host as an IPv4 address.
+    if let Ok(ipv4) = host.parse::<Ipv4Addr>() {
+        return Ok(ParseHostOutput { scheme, host: Host::Ipv4(ipv4), port });
+    }
+
+    // Attempt to parse the host as an IPv6 address enclosed in square brackets.
+    if input.starts_with('[') && input.ends_with(']') {
+        let ipv6 = &input[1..input.len() - 1];
+        if let Ok(ipv6) = ipv6.parse::<Ipv6Addr>() {
+            return Ok(ParseHostOutput { scheme, host: Host::Ipv6(ipv6), port });
+        }
+    }
+    // Attempt to parse the host as an IPv6 address.
+    if let Ok(ipv6) = input.parse::<Ipv6Addr>() {
+        return Ok(ParseHostOutput { scheme, host: Host::Ipv6(ipv6), port });
+    }
+
+    // Attempt to parse the host as a hostname.
+    if host.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+        return Ok(ParseHostOutput { scheme, host: Host::Hostname(host), port });
+    }
+
+    // Attempt to parse the host as a domain.
+    let does_not_start_with_dot = !host.starts_with('.');
+    let does_not_end_with_dot = !host.ends_with('.');
+    let has_at_least_one_dot = host.contains('.');
+    let dots_are_separated_by_valid_chars = host.split('.').all(|part| {
+        let part_does_not_start_with_hyphen = !part.starts_with('-');
+        let part_does_not_end_with_hyphen = !part.ends_with('-');
+        part_does_not_start_with_hyphen && part_does_not_end_with_hyphen && part.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+    });
+    let does_not_start_with_hyphen = !host.starts_with('-');
+    let does_not_end_with_hyphen = !host.ends_with('-');
+    let has_atleast_one_hyphen = host.contains('-');
+    let hyphens_are_separated_by_valid_chars =
+        has_atleast_one_hyphen.then(|| host.split('-').all(|part| part.chars().all(|c| c.is_ascii_alphanumeric())));
+    let tld = host.split('.').last();
+    // Prevents e.g. numbers being used as TLDs (which in turn prevents e.g. mistakes in IPv4 addresses as being detected as a domain).
+    let tld_exists_and_is_not_number = tld
+        .map(|tld| {
+            let tld_is_not_number = tld.parse::<i32>().is_err();
+            tld_is_not_number
+        })
+        .unwrap_or(false);
+
+    if does_not_start_with_dot
+        && does_not_end_with_dot
+        && has_at_least_one_dot
+        && dots_are_separated_by_valid_chars
+        && does_not_start_with_hyphen
+        && does_not_end_with_hyphen
+        && hyphens_are_separated_by_valid_chars.unwrap_or(true)
+        && tld_exists_and_is_not_number
+    {
+        return Ok(ParseHostOutput { scheme, host: Host::Domain(host), port });
+    }
+
+    Err(ParseHostError::InvalidInput)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_host_ip_v4_only_loopback() {
+        let input = "127.0.0.1";
+        let output = parse_host(input).unwrap();
+        assert_eq!(output.scheme, None);
+        assert_eq!(output.host, Host::Ipv4(Ipv4Addr::new(127, 0, 0, 1)));
+        assert_eq!(output.port, None);
+    }
+
+    #[test]
+    fn parse_host_ip_v4_only_invalid() {
+        let input = "127.0.0.256";
+        let output = parse_host(input);
+        assert!(output.is_err());
+        let err = output.unwrap_err();
+        assert_eq!(err, ParseHostError::InvalidInput);
+    }
+
+    #[test]
+    fn parse_host_ip_v4_with_port() {
+        let input = "127.0.0.1:8080";
+        let output = parse_host(input).unwrap();
+        assert_eq!(output.scheme, None);
+        assert_eq!(output.host, Host::Ipv4(Ipv4Addr::new(127, 0, 0, 1)));
+        assert_eq!(output.port, Some(8080));
+    }
+
+    #[test]
+    fn parse_host_ip_v4_with_port_and_loopback() {
+        let input = "ws://127.0.0.1:8080";
+        let output = parse_host(input).unwrap();
+        assert_eq!(output.scheme, Some("ws"));
+        assert_eq!(output.host, Host::Ipv4(Ipv4Addr::new(127, 0, 0, 1)));
+        assert_eq!(output.port, Some(8080));
+    }
+
+    #[test]
+    fn parse_host_ip_v6_only_loopback() {
+        let input = "::1";
+        let output = parse_host(input).unwrap();
+        assert_eq!(output.scheme, None);
+        assert_eq!(output.host, Host::Ipv6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)));
+        assert_eq!(output.port, None);
+    }
+
+    #[test]
+    fn parse_host_ip_v6_only_loopback_brackets() {
+        let input = "[::1]";
+        let output = parse_host(input).unwrap();
+        assert_eq!(output.scheme, None);
+        assert_eq!(output.host, Host::Ipv6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)));
+        assert_eq!(output.port, None);
+    }
+}

--- a/rpc/wrpc/client/src/parse.rs
+++ b/rpc/wrpc/client/src/parse.rs
@@ -36,7 +36,7 @@ impl ToString for Host<'_> {
             Host::Domain(domain) => domain.to_string(),
             Host::Hostname(hostname) => hostname.to_string(),
             Host::Ipv4(ipv4) => ipv4.to_string(),
-            Host::Ipv6(ipv6) => ipv6.to_string(),
+            Host::Ipv6(ipv6) => format!("[{}]", ipv6),
         }
     }
 }

--- a/rpc/wrpc/client/src/parse.rs
+++ b/rpc/wrpc/client/src/parse.rs
@@ -108,17 +108,12 @@ pub fn parse_host(input: &str) -> Result<ParseHostOutput, ParseHostError> {
     });
     let does_not_start_with_hyphen = !host.starts_with('-');
     let does_not_end_with_hyphen = !host.ends_with('-');
-    let has_atleast_one_hyphen = host.contains('-');
+    let has_at_least_one_hyphen = host.contains('-');
     let hyphens_are_separated_by_valid_chars =
-        has_atleast_one_hyphen.then(|| host.split('-').all(|part| part.chars().all(|c| c.is_ascii_alphanumeric())));
+        has_at_least_one_hyphen.then(|| host.split('-').all(|part| part.chars().all(|c| c.is_ascii_alphanumeric())));
     let tld = host.split('.').last();
     // Prevents e.g. numbers being used as TLDs (which in turn prevents e.g. mistakes in IPv4 addresses as being detected as a domain).
-    let tld_exists_and_is_not_number = tld
-        .map(|tld| {
-            let tld_is_not_number = tld.parse::<i32>().is_err();
-            tld_is_not_number
-        })
-        .unwrap_or(false);
+    let tld_exists_and_is_not_number = tld.map(|tld| tld.parse::<i32>().is_err()).unwrap_or(false);
 
     if does_not_start_with_dot
         && does_not_end_with_dot

--- a/rpc/wrpc/client/src/parse.rs
+++ b/rpc/wrpc/client/src/parse.rs
@@ -24,6 +24,13 @@ pub enum ParseHostError {
     ParsePortError(ParseIntError),
 }
 
+/// Parses a host string into a scheme, host, and port.
+///
+/// The host string can either be a hostname, domain, IPv4 address, or IPv6 address with optionally including the scheme and port.
+///
+/// IPv6 addresses are optionally enclosed in square brackets, and required if specifying a port.
+///
+/// If a path is attached to the host string, it will be discarded.
 pub fn parse_host(input: &str) -> Result<ParseHostOutput, ParseHostError> {
     // Attempt to split the input into scheme, host, and port.
     let (scheme, input) = match input.find("://") {


### PR DESCRIPTION
- Introduced `parse_host` which parses a host string into a scheme, host, and port if present.
The host string can either be a hostname, domain, IPv4 address, or IPv6 address with optionally including the scheme and port.
- Updated the `parse_url` function to use this function