### PR TITLE
update account and wallet import handlers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ members = [
 version = "0.1.7"
 authors = ["Kaspa developers"]
 license = "MIT/Apache-2.0"
+repository = "https://github.com/kaspanet/rusty-kaspa"
 edition = "2021"
 include = [
     "src/**/*.rs",

--- a/README.md
+++ b/README.md
@@ -4,13 +4,16 @@ This repository contains the implementation of the Kaspa full-node and related l
 
 ## Getting started
 
-- Install Protobuf (required for grpc)
+- General prerequisites:
+  - Linux: `sudo apt install build-essential libssl-dev pkg-config`
+  - Windows: [Git for Windows](https://gitforwindows.org/) or an alternative Git distribution.
+- Install Protobuf (required for gRPC)
   - Linux: `sudo apt install protobuf-compiler libprotobuf-dev`
-  - Windows: [protoc-21.10-win64.zip](https://github.com/protocolbuffers/protobuf/releases/download/v21.10/protoc-21.10-win64.zip) and add `bin` dir to `Path`
+  - Windows: [protoc-21.10-win64.zip](https://github.com/protocolbuffers/protobuf/releases/download/v21.10/protoc-21.10-win64.zip) and add `bin` directory to `Path`
   - MacOS: `brew install protobuf`
-- Install the [clang toolchain](https://clang.llvm.org/) (required for RocksDB)
+- Install the [clang toolchain](https://clang.llvm.org/) (required for RocksDB and WASM `secp256k1` builds)
   - Linux: `apt-get install clang-format clang-tidy clang-tools clang clangd libc++-dev libc++1 libc++abi-dev libc++abi1 libclang-dev libclang1 liblldb-dev libllvm-ocaml-dev libomp-dev libomp5 lld lldb llvm-dev llvm-runtime llvm python3-clang`
-  - Windows: [LLVM-15.0.6-win64.exe](https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/LLVM-15.0.6-win64.exe) and set `LIBCLANG_PATH` env var pointing to the `bin` dir of the llvm installation
+  - Windows: Please see [Installing clang toolchain on Windows](#installing-clang-toolchain-on-windows)
   - MacOS: Please see [Installing clang toolchain on MacOS](#installing-clang-toolchain-on-macos)
 - Install the [rust toolchain](https://rustup.rs/)
 - If you already have rust installed, update it by running: `rustup update`
@@ -83,7 +86,7 @@ It will produce `{bin-name}-heap.json` file in the root of the workdir, that can
 
 ## Tests & Benchmarks
 
-- To run all current tests use:
+- To run unit and most integration tests use:
 
 ```bash
 $ cd rusty-kaspa
@@ -109,6 +112,17 @@ cd wasm
 ```
 This will produce a wasm library in `/web-root` directory
 
+## Installing clang toolchain on Windows
+
+Install [LLVM-15.0.6-win64.exe](https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/LLVM-15.0.6-win64.exe)
+
+Once LLVM is installed:
+- Add the `bin` directory of the LLVM installation (`C:\Program Files\LLVM\bin`) to PATH
+- set `LIBCLANG_PATH` environment variable to point to the `bin` directory as well
+
+**IMPORTANT:** Due to C++ dependency configuration issues, LLVM `AR` installation on Windows may not function correctly when switching between WASM and native C++ code compilation (native `RocksDB+secp256k1` vs WASM32 builds of `secp256k1`). Unfortunately, manually setting `AR` environment variable also confuses C++ build toolchain (it should not be set for native but should be set for WASM32 targets). Currently, the best way to address this, is as follows: after installing LLVM on Windows, go to the target `bin` installation directory and copy or rename `LLVM_AR.exe` to `AR.exe`.
+
+
 ## Installing clang toolchain on MacOS
 
 The default XCode installation of `llvm` does not support WASM build targets.
@@ -117,18 +131,16 @@ To build WASM on MacOS you need to install `llvm` from homebrew (at the time of 
 ```bash
 brew install llvm
 ```
-NOTE: depending on your setup, the installation location may be different.
-To determine the installation location you can use `which llvm`, `which clang`
-or `brew list llvm` commands
-and then modify the paths below accordingly.
+**NOTE:** depending on your homebrew configuration, the installation location may be different.
+In some homebrew configurations it can be `/opt/homebrew/opt/llvm` while in others it can be `/usr/local/Cellar/llvm`.
 
+To determine the installation location you can use `brew list llvm` command and then modify the paths below accordingly:
 ```bash
 % brew list llvm
 /usr/local/Cellar/llvm/15.0.7_1/bin/FileCheck
 /usr/local/Cellar/llvm/15.0.7_1/bin/UnicodeNameMappingGenerator
+...
 ```
-should i replace 'opt/homebrew/opt' to ''/usr/local/Cellar/llvm/15.0.7_1"?
-
 
 Add the following to your `~/.zshrc` file:
 ```bash
@@ -137,7 +149,6 @@ export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"
 export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
 export AR=/opt/homebrew/opt/llvm/bin/llvm-ar
 ```
-
 
 Reload the `~/.zshrc` file
 ```bash
@@ -171,7 +182,8 @@ wRPC to gRPC Proxy is deprecated and no longer supported.
 
 Integration in a Browser and Node.js environments is possible using WASM.
 The JavaScript code is agnostic to which environment it runs in.
-NOTE: to run in Node.js environment, you must instantiate a W3C WebSocket
+
+**NOTE:** to run in Node.js environment, you must instantiate a W3C WebSocket
 shim using a `WebSocket` crate before initializing Kaspa environment:
 `globalThis.WebSocket = require('websocket').w3cwebsocket;`
 
@@ -193,7 +205,7 @@ node index
 
 You can take a look at `rpc/wrpc/wasm/nodejs/index.js` to see the use of the native JavaScript & TypeScript APIs.
 
-NOTE: `npm install` is needed to install [WebSocket](https://github.com/theturtle32/WebSocket-Node) module.
+**NOTE:** `npm install` is needed to install [WebSocket](https://github.com/theturtle32/WebSocket-Node) module.
 When running in the Browser environment, no additional dependencies are necessary because
 the browser provides the W3C WebSocket class natively.
 

--- a/cli/src/modules/account.rs
+++ b/cli/src/modules/account.rs
@@ -59,6 +59,98 @@ impl Account {
                 let account_name = account_name.as_deref();
                 wizards::account::create(&ctx, prv_key_data_info, account_kind, account_name).await?;
             }
+            "import" => {
+                if argv.is_empty() {
+                    tprintln!(ctx, "usage: 'account import <import-type> <key-type> [extra keys]'");
+                    tprintln!(ctx, "");
+                    tprintln!(ctx, "examples:");
+                    tprintln!(ctx, "");
+                    ctx.term().help(
+                        &[
+                            ("account import legacy-data", "Import KDX keydata file or kaspanet web wallet data on the same domain"),
+                            (
+                                "account import mnemonic bip32",
+                                "Import Bip32 (12 or 24 word mnemonics used by kaspawallet, kaspium, onekey, tangem etc.)",
+                            ),
+                            (
+                                "account import mnemonic legacy",
+                                "Import accounts 12 word mnemonic used by legacy applications (KDX and kaspanet web wallet)",
+                            ),
+                            (
+                                "account import mnemonic multisig [additional keys]",
+                                "Import mnemonic and additional keys for a multisig account",
+                            ),
+                        ],
+                        None,
+                    )?;
+
+                    return Ok(());
+                }
+
+                let import_kind = argv.remove(0);
+                match import_kind.as_ref() {
+                    "legacy-data" => {
+                        if !argv.is_empty() {
+                            tprintln!(ctx, "usage: 'account import legacy-data'");
+                            tprintln!(ctx, "too many arguments: {}\r\n", argv.join(" "));
+                            return Ok(());
+                        }
+
+                        if exists_legacy_v0_keydata().await? {
+                            let import_secret = Secret::new(
+                                ctx.term()
+                                    .ask(true, "Enter the password for the account you are importing: ")
+                                    .await?
+                                    .trim()
+                                    .as_bytes()
+                                    .to_vec(),
+                            );
+                            let wallet_secret =
+                                Secret::new(ctx.term().ask(true, "Enter wallet password: ").await?.trim().as_bytes().to_vec());
+                            wallet.import_gen0_keydata(import_secret, wallet_secret, None).await?;
+                        } else if application_runtime::is_web() {
+                            return Err("'kaspanet' web wallet storage not found at this domain name".into());
+                        } else {
+                            return Err("KDX keydata file not found".into());
+                        }
+                    }
+                    "mnemonic" => {
+                        if argv.is_empty() {
+                            tprintln!(ctx, "usage: 'account import mnemonic <bip32|legacy|multisig>'");
+                            tprintln!(ctx, "please specify the mnemonic type");
+                            tprintln!(ctx, "please use 'legacy' for 12-word KDX and kaspanet web wallet mnemonics\r\n");
+                            return Ok(());
+                        }
+
+                        let account_kind = argv.remove(0);
+                        let account_kind = account_kind.parse::<AccountKind>()?;
+
+                        match account_kind {
+                            AccountKind::Legacy | AccountKind::Bip32 => {
+                                if !argv.is_empty() {
+                                    tprintln!(ctx, "too many arguments: {}\r\n", argv.join(" "));
+                                    return Ok(());
+                                }
+                                crate::wizards::import::import_with_mnemonic(&ctx, account_kind, &argv).await?;
+                            }
+                            AccountKind::MultiSig => {
+                                crate::wizards::import::import_with_mnemonic(&ctx, account_kind, &argv).await?;
+                            }
+                            _ => {
+                                tprintln!(ctx, "account import is not supported for this account type: '{account_kind}'\r\n");
+                                return Ok(());
+                            }
+                        }
+
+                        return Ok(());
+                    }
+                    _ => {
+                        tprintln!(ctx, "unknown account import type: '{import_kind}'");
+                        tprintln!(ctx, "supported import types are: 'mnemonic' or 'legacy-data'\r\n");
+                        return Ok(());
+                    }
+                }
+            }
             "scan" | "sweep" => {
                 let len = argv.len();
                 let mut start = 0;
@@ -90,7 +182,11 @@ impl Account {
         ctx.term().help(
             &[
                 ("create [<type>] [<name>]", "Create a new account (types: 'bip32' (default), 'legacy', 'multisig')"),
-                // ("import", "Import a private key using 24 or 12 word mnemonic"),
+                (
+                    "import <import-type> [<key-type> [extra keys]]",
+                    "Import accounts from a private key using 24 or 12 word mnemonic or legacy data \
+                (KDX and kaspanet web wallet). Use 'account import' for additional help.",
+                ),
                 ("name <name>", "Name or rename the selected account (use 'remove' to remove the name"),
                 ("scan [<derivations>] or scan [<start>] [<derivations>]", "Scan extended address derivation chain (legacy accounts)"),
                 (

--- a/cli/src/modules/mod.rs
+++ b/cli/src/modules/mod.rs
@@ -16,7 +16,7 @@ pub mod guide;
 pub mod halt;
 pub mod help;
 pub mod history;
-pub mod import;
+// pub mod import;
 pub mod list;
 pub mod message;
 pub mod miner;
@@ -52,8 +52,8 @@ pub fn register_handlers(cli: &Arc<KaspaCli>) -> Result<()> {
         cli,
         cli.handlers(),
         [
-            account, address, close, connect, details, disconnect, estimate, exit, export, guide, help, history, import, rpc, list,
-            miner, message, monitor, mute, network, node, open, ping, reload, select, send, server, settings, sweep, track, transfer,
+            account, address, close, connect, details, disconnect, estimate, exit, export, guide, help, history, rpc, list, miner,
+            message, monitor, mute, network, node, open, ping, reload, select, send, server, settings, sweep, track, transfer,
             wallet,
             // halt,
             // theme,  start, stop

--- a/cli/src/wizards/import.rs
+++ b/cli/src/wizards/import.rs
@@ -6,7 +6,7 @@ use kaspa_bip32::{Language, Mnemonic};
 use kaspa_wallet_core::storage::AccountKind;
 use std::sync::Arc;
 
-pub async fn ask(term: &Arc<Terminal>) -> Result<Vec<String>> {
+pub async fn prompt_for_mnemonic(term: &Arc<Terminal>) -> Result<Vec<String>> {
     let mut words: Vec<String> = vec![];
     loop {
         if words.is_empty() {
@@ -52,7 +52,7 @@ pub(crate) async fn import_with_mnemonic(ctx: &Arc<KaspaCli>, account_kind: Acco
     tprintln!(ctx);
     let wallet_secret = Secret::new(term.ask(true, "Enter wallet password: ").await?.trim().as_bytes().to_vec());
     tprintln!(ctx);
-    let mnemonic = ask(&term).await?;
+    let mnemonic = prompt_for_mnemonic(&term).await?;
     tprintln!(ctx);
     let length = mnemonic.len();
     match account_kind {
@@ -70,15 +70,15 @@ pub(crate) async fn import_with_mnemonic(ctx: &Arc<KaspaCli>, account_kind: Acco
             ctx,
             "\
             \
-            If your original wallet has a recovery passphrase, please enter it now.\
+            If your original wallet has a bip39 recovery passphrase, please enter it now.\
             \
-            Specifically, this is not a wallet password. This is a secondary payment password\
-            used to encrypt your private key. This is known as a 'payment passphrase'\
-            'mnemonic password', or a 'recovery passphrase'. If your mnemonic was created\
+            Specifically, this is not a wallet password. This is a secondary mnemonic passphrase\
+            used to encrypt your mnemonic. This is known as a 'payment passphrase'\
+            'mnemonic passphrase', or a 'recovery passphrase'. If your mnemonic was created\
             with a payment passphrase and you do not enter it now, the import process\
             will generate a different private key.\
             \
-            If you do not have a payment password, just press ENTER.\
+            If you do not have a bip39 recovery passphrase, press ENTER.\
             \
             ",
         );
@@ -103,7 +103,7 @@ pub(crate) async fn import_with_mnemonic(ctx: &Arc<KaspaCli>, account_kind: Acco
             "y" | "Y" | "YES" | "yes"
         ) {
             tprintln!(ctx);
-            let mnemonic = ask(&term).await?;
+            let mnemonic = prompt_for_mnemonic(&term).await?;
             tprintln!(ctx);
             let payment_secret = term.ask(true, "Enter payment password (optional): ").await?;
             let payment_secret = payment_secret.trim().is_not_empty().then(|| Secret::new(payment_secret.trim().as_bytes().to_vec()));

--- a/cli/src/wizards/wallet.rs
+++ b/cli/src/wizards/wallet.rs
@@ -4,7 +4,7 @@ use crate::result::Result;
 use kaspa_wallet_core::runtime::{PrvKeyDataCreateArgs, WalletCreateArgs};
 use kaspa_wallet_core::storage::{AccessContextT, AccountKind, Hint};
 
-pub(crate) async fn create(ctx: &Arc<KaspaCli>, name: Option<&str>) -> Result<()> {
+pub(crate) async fn create(ctx: &Arc<KaspaCli>, name: Option<&str>, import_with_mnemonic: bool) -> Result<()> {
     let term = ctx.term();
     let wallet = ctx.wallet();
 
@@ -37,14 +37,14 @@ pub(crate) async fn create(ctx: &Arc<KaspaCli>, name: Option<&str>) -> Result<()
     tpara!(
         ctx,
         "\n\
-    \"Phishing hint\" is a secret word or a phrase that is displayed \
-    when you open your wallet. If you do not see the hint when opening \
-    your wallet, you may be accessing a fake wallet designed to steal \
-    your private key. If this occurs, stop using the wallet immediately, \
-    check the browser URL domain name and seek help on social networks \
-    (Kaspa Discord or Telegram). \
-    \n\
-    ",
+        \"Phishing hint\" is a secret word or a phrase that is displayed \
+        when you open your wallet. If you do not see the hint when opening \
+        your wallet, you may be accessing a fake wallet designed to steal \
+        your private key. If this occurs, stop using the wallet immediately, \
+        check the browser URL domain name and seek help on social networks \
+        (Kaspa Discord or Telegram). \
+        \n\
+        ",
     );
 
     let hint = term.ask(false, "Create phishing hint (optional, press <enter> to skip): ").await?.trim().to_string();
@@ -62,24 +62,44 @@ pub(crate) async fn create(ctx: &Arc<KaspaCli>, name: Option<&str>) -> Result<()
     }
 
     tprintln!(ctx, "");
-    tpara!(
-        ctx,
-        "\
-        PLEASE NOTE: The optional payment password, if provided, will be required to \
-        issue transactions. This password will also be required when recovering your wallet \
-        in addition to your private key or mnemonic. If you loose this password, you will not \
-        be able to use mnemonic to recover your wallet! \
-        ",
-    );
+    if import_with_mnemonic {
+        tpara!(
+            ctx,
+            "\
+            \
+            If your original wallet has a bip39 recovery passphrase, please enter it now.\
+            \
+            Specifically, this is not a wallet password. This is a secondary mnemonic passphrase\
+            used to encrypt your mnemonic. This is known as a 'payment passphrase'\
+            'mnemonic passphrase', or a 'recovery passphrase'. If your mnemonic was created\
+            with a payment passphrase and you do not enter it now, the import process\
+            will generate a different private key.\
+            \
+            If you do not have a bip39 recovery passphrase, press ENTER.\
+            \
+            ",
+        );
+    } else {
+        tpara!(
+            ctx,
+            "\
+            PLEASE NOTE: The optional bip39 mnemonic passphrase, if provided, will be required to \
+            issue transactions. This passphrase will also be required when recovering your wallet \
+            in addition to your private key or mnemonic. If you loose this passphrase, you will not \
+            be able to use or recover your wallet! \
+            \
+            If you do not want to use bip39 recovery passphrase, press ENTER.\
+            ",
+        );
+    }
 
-    let payment_secret = term.ask(true, "Enter payment password (optional): ").await?;
+    let payment_secret = term.ask(true, "Enter bip39 mnemonic passphrase (optional): ").await?;
     let payment_secret =
         if payment_secret.trim().is_empty() { None } else { Some(Secret::new(payment_secret.trim().as_bytes().to_vec())) };
 
     if let Some(payment_secret) = payment_secret.as_ref() {
-        let payment_secret_validate = Secret::new(
-            term.ask(true, "Enter payment (private key encryption) password (optional): ").await?.trim().as_bytes().to_vec(),
-        );
+        let payment_secret_validate =
+            Secret::new(term.ask(true, "Please re-enter mnemonic passphrase: ").await?.trim().as_bytes().to_vec());
         if payment_secret_validate.as_ref() != payment_secret.as_ref() {
             return Err(Error::PaymentSecretMatch);
         }
@@ -87,13 +107,20 @@ pub(crate) async fn create(ctx: &Arc<KaspaCli>, name: Option<&str>) -> Result<()
 
     tprintln!(ctx, "");
 
+    let prv_key_data_args = if import_with_mnemonic {
+        let words = crate::wizards::import::prompt_for_mnemonic(&term).await?;
+        PrvKeyDataCreateArgs::new_with_mnemonic(None, wallet_secret.clone(), payment_secret.clone(), words.join(" "))
+    } else {
+        PrvKeyDataCreateArgs::new(None, wallet_secret.clone(), payment_secret.clone())
+    };
+
     let notifier = ctx.notifier().show(Notification::Processing).await;
+
     // suspend commits for multiple operations
     wallet.store().batch().await?;
 
     let account_kind = AccountKind::Bip32;
     let wallet_args = WalletCreateArgs::new(name.map(String::from), None, hint, wallet_secret.clone(), true);
-    let prv_key_data_args = PrvKeyDataCreateArgs::new(None, wallet_secret.clone(), payment_secret.clone());
     let account_args = AccountCreateArgs::new(account_name, account_title, account_kind, wallet_secret.clone(), payment_secret);
     let descriptor = ctx.wallet().create_wallet(wallet_args).await?;
     let (prv_key_data_id, mnemonic) = wallet.create_prv_key_data(prv_key_data_args).await?;
@@ -102,31 +129,34 @@ pub(crate) async fn create(ctx: &Arc<KaspaCli>, name: Option<&str>) -> Result<()
     // flush data to storage
     let access_ctx: Arc<dyn AccessContextT> = Arc::new(AccessContext::new(wallet_secret.clone()));
     wallet.store().flush(&access_ctx).await?;
+
     notifier.hide();
 
-    tprintln!(ctx, "");
-    tprintln!(ctx, "---");
-    tprintln!(ctx, "");
-    tprintln!(ctx, "{}", style("IMPORTANT:").red());
-    tprintln!(ctx, "");
+    if !import_with_mnemonic {
+        tprintln!(ctx, "");
+        tprintln!(ctx, "---");
+        tprintln!(ctx, "");
+        tprintln!(ctx, "{}", style("IMPORTANT:").red());
+        tprintln!(ctx, "");
 
-    tpara!(
-        ctx,
-        "Your mnemonic phrase allows your to re-create your private key. \
-        The person who has access to this mnemonic will have full control of \
-        the Kaspa stored in it. Keep your mnemonic safe. Write it down and \
-        store it in a safe, preferably in a fire-resistant location. Do not \
-        store your mnemonic on this computer or a mobile device. This wallet \
-        will never ask you for this mnemonic phrase unless you manually \
-        initiate a private key recovery. \
-        ",
-    );
+        tpara!(
+            ctx,
+            "Your mnemonic phrase allows your to re-create your private key. \
+            The person who has access to this mnemonic will have full control of \
+            the Kaspa stored in it. Keep your mnemonic safe. Write it down and \
+            store it in a safe, preferably in a fire-resistant location. Do not \
+            store your mnemonic on this computer or a mobile device. This wallet \
+            will never ask you for this mnemonic phrase unless you manually \
+            initiate a private key recovery. \
+            ",
+        );
 
-    // descriptor
+        // descriptor
 
-    ["", "Never share your mnemonic with anyone!", "---", "", "Your default wallet account mnemonic:", mnemonic.phrase()]
-        .into_iter()
-        .for_each(|line| term.writeln(line));
+        ["", "Never share your mnemonic with anyone!", "---", "", "Your default wallet account mnemonic:", mnemonic.phrase()]
+            .into_iter()
+            .for_each(|line| term.writeln(line));
+    }
 
     term.writeln("");
     if let Some(descriptor) = descriptor {

--- a/cli/src/wizards/wallet.rs
+++ b/cli/src/wizards/wallet.rs
@@ -2,7 +2,7 @@ use crate::cli::KaspaCli;
 use crate::imports::*;
 use crate::result::Result;
 use kaspa_wallet_core::runtime::{PrvKeyDataCreateArgs, WalletCreateArgs};
-use kaspa_wallet_core::storage::{AccessContextT, AccountKind, Hint};
+use kaspa_wallet_core::storage::{make_filename, AccessContextT, AccountKind, Hint};
 
 pub(crate) async fn create(ctx: &Arc<KaspaCli>, name: Option<&str>, import_with_mnemonic: bool) -> Result<()> {
     let term = ctx.term();
@@ -16,8 +16,8 @@ pub(crate) async fn create(ctx: &Arc<KaspaCli>, name: Option<&str>, import_with_
         tprintln!(ctx);
         return Err(err.into());
     }
-
-    if wallet.exists(name).await? {
+    let filename = make_filename(&name.map(String::from), &None);
+    if wallet.exists(Some(&filename)).await? {
         tprintln!(ctx, "{}", style("WARNING - A previously created wallet already exists!").red().to_string());
         tprintln!(ctx, "NOTE: You can create a differently named wallet by using 'wallet create <name>'");
         tprintln!(ctx);

--- a/kaspad/Cargo.toml
+++ b/kaspad/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 include.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [lib]
 name = "kaspad_lib"

--- a/kaspad/README.md
+++ b/kaspad/README.md
@@ -1,0 +1,5 @@
+# Kaspa p2p Node
+
+High-performance p2p node library and daemon for high-BPS BlockDAG [Kaspa](https://kaspa.org) network developed in Rust.
+
+For more information please refer to the GitHub repository `README.md` located at https://github.com/kaspanet/rusty-kaspa

--- a/kos/build.ps1
+++ b/kos/build.ps1
@@ -1,7 +1,7 @@
 cargo fmt --all
 
 if ($args.Contains("--dev")) {
-    & "wasm-pack build --dev --target web --out-name kaspa --out-dir app/wasm"
+    & "wasm-pack" build --dev --target web --out-name kaspa --out-dir app/wasm
 } else {
-    & "wasm-pack build --target web --out-name kaspa --out-dir app/wasm"
+    & "wasm-pack" build --target web --out-name kaspa --out-dir app/wasm
 }

--- a/wallet/core/src/runtime/account/mod.rs
+++ b/wallet/core/src/runtime/account/mod.rs
@@ -33,7 +33,7 @@ use super::AtomicBalance;
 pub const DEFAULT_AMOUNT_PADDING: usize = 19;
 
 pub type GenerationNotifier = Arc<dyn Fn(&PendingTransaction) + Send + Sync>;
-pub type DeepScanNotifier = Arc<dyn Fn(usize, u64, Option<TransactionId>) + Send + Sync>;
+pub type ScanNotifier = Arc<dyn Fn(usize, u64, Option<TransactionId>) + Send + Sync>;
 
 pub struct Context {
     pub settings: Option<storage::account::Settings>,
@@ -412,7 +412,7 @@ pub trait DerivationCapableAccount: Account {
         window: usize,
         sweep: bool,
         abortable: &Abortable,
-        notifier: Option<DeepScanNotifier>,
+        notifier: Option<ScanNotifier>,
     ) -> Result<()> {
         self.clone().initialize_private_data(wallet_secret.clone(), payment_secret.as_ref(), None).await?;
 

--- a/wallet/core/src/runtime/wallet.rs
+++ b/wallet/core/src/runtime/wallet.rs
@@ -66,13 +66,8 @@ impl PrvKeyDataCreateArgs {
         Self { name, wallet_secret, payment_secret, mnemonic: None }
     }
 
-    pub fn new_with_mnemonic(
-        name: Option<String>,
-        wallet_secret: Secret,
-        payment_secret: Option<Secret>,
-        mnemonic: Option<String>,
-    ) -> Self {
-        Self { name, wallet_secret, payment_secret, mnemonic }
+    pub fn new_with_mnemonic(name: Option<String>, wallet_secret: Secret, payment_secret: Option<Secret>, mnemonic: String) -> Self {
+        Self { name, wallet_secret, payment_secret, mnemonic: Some(mnemonic) }
     }
 }
 

--- a/wallet/core/src/runtime/wallet.rs
+++ b/wallet/core/src/runtime/wallet.rs
@@ -1,6 +1,6 @@
 use crate::imports::*;
 use crate::result::Result;
-use crate::runtime::{try_from_storage, Account, AccountId, ActiveAccountMap};
+use crate::runtime::{account::ScanNotifier, try_from_storage, Account, AccountId, ActiveAccountMap};
 use crate::secret::Secret;
 use crate::settings::{SettingsStore, WalletSettings};
 use crate::storage::interface::{AccessContext, CreateArgs, OpenArgs};
@@ -843,7 +843,9 @@ impl Wallet {
         import_secret: Secret,
         wallet_secret: Secret,
         payment_secret: Option<&Secret>,
+        notifier: Option<ScanNotifier>,
     ) -> Result<Arc<dyn Account>> {
+        let notifier = notifier.as_ref();
         let keydata = load_v0_keydata(&import_secret).await?;
 
         let ctx: Arc<dyn AccessContextT> = Arc::new(AccessContext::new(wallet_secret.clone()));
@@ -859,24 +861,33 @@ impl Wallet {
         let settings = storage::Settings::default();
         let account = Arc::new(runtime::account::Legacy::try_new(self, prv_key_data.id, settings, data, None).await?);
 
-        account.clone().initialize_private_data(wallet_secret, payment_secret, None).await?;
-
         // activate account (add it to wallet active account list)
         self.active_accounts().insert(account.clone().as_dyn_arc());
         self.legacy_accounts().insert(account.clone().as_dyn_arc());
 
-        if self.is_connected() {
-            account.clone().scan(Some(100), Some(50000)).await?;
-        }
-
         let account_store = self.inner.store.as_account_store()?;
         let stored_account = account.as_storable()?;
-
         // store private key and account
         self.inner.store.batch().await?;
         prv_key_data_store.store(&ctx, prv_key_data).await?;
         account_store.store_single(&stored_account, None).await?;
         self.inner.store.flush(&ctx).await?;
+
+        account.clone().initialize_private_data(wallet_secret, payment_secret, None).await?;
+
+        if self.is_connected() {
+            if let Some(notifier) = notifier {
+                notifier(0, 0, None);
+            }
+            account.clone().scan(Some(100), Some(5000)).await?;
+        }
+
+        let derivation = account.clone().as_derivation_capable()?.derivation();
+        let m = derivation.receive_address_manager();
+        m.get_range(0..(m.index() + CACHE_ADDRESS_OFFSET))?;
+        let m = derivation.change_address_manager();
+        m.get_range(0..(m.index() + CACHE_ADDRESS_OFFSET))?;
+        account.clone().clear_private_data().await?;
 
         account.clone().clear_private_data().await?;
 

--- a/wallet/core/src/runtime/wallet.rs
+++ b/wallet/core/src/runtime/wallet.rs
@@ -6,7 +6,9 @@ use crate::settings::{SettingsStore, WalletSettings};
 use crate::storage::interface::{AccessContext, CreateArgs, OpenArgs};
 use crate::storage::local::interface::LocalStore;
 use crate::storage::local::Storage;
-use crate::storage::{self, AccessContextT, AccountData, AccountKind, Hint, Interface, PrvKeyData, PrvKeyDataId, PrvKeyDataInfo};
+use crate::storage::{
+    self, make_filename, AccessContextT, AccountData, AccountKind, Hint, Interface, PrvKeyData, PrvKeyDataId, PrvKeyDataInfo,
+};
 use crate::utxo::UtxoProcessor;
 #[allow(unused_imports)]
 use crate::{derivation::gen0, derivation::gen0::import::*, derivation::gen1, derivation::gen1::import::*};
@@ -275,8 +277,9 @@ impl Wallet {
     /// Loads a wallet from storage. Accounts are not activated by this call.
     async fn load_impl(self: &Arc<Wallet>, secret: Secret, name: Option<String>) -> Result<()> {
         let name = name.or_else(|| self.settings().get(WalletSettings::Wallet));
+        let name = Some(make_filename(&name, &None));
         let ctx: Arc<dyn AccessContextT> = Arc::new(AccessContext::new(secret));
-        self.store().open(&ctx, OpenArgs::new(name.clone())).await?;
+        self.store().open(&ctx, OpenArgs::new(name)).await?;
 
         // reset current state only after we have successfully opened another wallet
         self.reset(true).await?;
@@ -302,8 +305,9 @@ impl Wallet {
     /// Loads a wallet from storage. Accounts are activated by this call.
     pub async fn load_and_activate(self: &Arc<Wallet>, secret: Secret, name: Option<String>) -> Result<()> {
         let name = name.or_else(|| self.settings().get(WalletSettings::Wallet));
+        let name = Some(make_filename(&name, &None));
         let ctx: Arc<dyn AccessContextT> = Arc::new(AccessContext::new(secret.clone()));
-        self.store().open(&ctx, OpenArgs::new(name.clone())).await?;
+        self.store().open(&ctx, OpenArgs::new(name)).await?;
 
         // reset current state only after we have successfully opened another wallet
         self.reset(true).await?;

--- a/wallet/core/src/storage/local/interface.rs
+++ b/wallet/core/src/storage/local/interface.rs
@@ -18,7 +18,7 @@ use std::sync::atomic::Ordering;
 use workflow_core::runtime::is_web;
 use workflow_store::fs;
 
-fn make_filename(title: &Option<String>, filename: &Option<String>) -> String {
+pub fn make_filename(title: &Option<String>, filename: &Option<String>) -> String {
     if let Some(filename) = filename {
         filename.to_string()
     } else if let Some(title) = title {

--- a/wallet/core/src/storage/local/interface.rs
+++ b/wallet/core/src/storage/local/interface.rs
@@ -221,7 +221,7 @@ impl Interface for LocalStore {
 
     async fn exists(&self, name: Option<&str>) -> Result<bool> {
         let location = self.location.lock().unwrap().clone().unwrap();
-        let store = Storage::try_new_with_folder(&location.folder, name.unwrap_or(super::DEFAULT_WALLET_FILE))?;
+        let store = Storage::try_new_with_folder(&location.folder, &format!("{}.wallet", name.unwrap_or(super::DEFAULT_WALLET_FILE)))?;
         store.exists().await
     }
 

--- a/wallet/core/src/storage/mod.rs
+++ b/wallet/core/src/storage/mod.rs
@@ -19,6 +19,7 @@ pub use hint::Hint;
 pub use id::IdT;
 pub use interface::{AccessContextT, AccountStore, Interface, PrvKeyDataStore, TransactionRecordStore, WalletDescriptor};
 pub use keydata::{KeyCaps, PrvKeyData, PrvKeyDataId, PrvKeyDataInfo, PrvKeyDataMap, PrvKeyDataPayload};
+pub use local::interface::make_filename;
 pub use metadata::Metadata;
 pub use transaction::{TransactionMetadata, TransactionRecord, TransactionType};
 


### PR DESCRIPTION
- remove the base `import` handler
- create `account import` handler capable of importing kaspawallet and legacy (`/927/`) accounts
- create `wallet import` handler capable of importing mnemonics (bip32 `/111111/` only)