### PR TITLE
Update CLI to use a public node Resolver

### DIFF
--- a/cli/src/modules/connect.rs
+++ b/cli/src/modules/connect.rs
@@ -9,20 +9,32 @@ impl Connect {
     async fn main(self: Arc<Self>, ctx: &Arc<dyn Context>, argv: Vec<String>, _cmd: &str) -> Result<()> {
         let ctx = ctx.clone().downcast_arc::<KaspaCli>()?;
         if let Some(wrpc_client) = ctx.wallet().try_wrpc_client().as_ref() {
-            let url = argv.first().cloned().or_else(|| ctx.wallet().settings().get(WalletSettings::Server));
             let network_id = ctx.wallet().network_id()?;
 
-            let url = match url.as_deref() {
+            let arg_or_server_address = argv.first().cloned().or_else(|| ctx.wallet().settings().get(WalletSettings::Server));
+            let (is_public, url) = match arg_or_server_address.as_deref() {
                 Some("public") => {
                     tprintln!(ctx, "Connecting to a public node");
-                    Resolver::default().fetch(WrpcEncoding::Borsh, network_id).await.map_err(|e| e.to_string())?.url
+                    (true, Resolver::default().fetch(WrpcEncoding::Borsh, network_id).await.map_err(|e| e.to_string())?.url)
                 }
                 None => {
                     tprintln!(ctx, "No server set, connecting to a public node");
-                    Resolver::default().fetch(WrpcEncoding::Borsh, network_id).await.map_err(|e| e.to_string())?.url
+                    (true, Resolver::default().fetch(WrpcEncoding::Borsh, network_id).await.map_err(|e| e.to_string())?.url)
                 }
-                Some(url) => wrpc_client.parse_url_with_network_type(url.to_string(), network_id.into()).map_err(|e| e.to_string())?,
+                Some(url) => {
+                    (false, wrpc_client.parse_url_with_network_type(url.to_string(), network_id.into()).map_err(|e| e.to_string())?)
+                }
             };
+
+            if is_public {
+                tpara!(
+                    ctx,
+                    "Please note that default public nodes are community-operated and \
+                    accessing them may expose your IP address to different node providers. \
+                    Consider running your own node for better privacy. \
+                    ",
+                );
+            }
 
             let options = ConnectOptions {
                 block_async_connect: true,

--- a/cli/src/modules/connect.rs
+++ b/cli/src/modules/connect.rs
@@ -16,17 +16,20 @@ impl Connect {
                 Some("public") => {
                     tprintln!(ctx, "Connecting to a public node");
                     Resolver::default().fetch(WrpcEncoding::Borsh, network_id).await.map_err(|e| e.to_string())?.url
-                },
+                }
                 None => {
                     tprintln!(ctx, "No server set, connecting to a public node");
                     Resolver::default().fetch(WrpcEncoding::Borsh, network_id).await.map_err(|e| e.to_string())?.url
-                },
-                Some(url) => {
-                    wrpc_client.parse_url_with_network_type(url.to_string(), network_id.into()).map_err(|e| e.to_string())?
-                },
+                }
+                Some(url) => wrpc_client.parse_url_with_network_type(url.to_string(), network_id.into()).map_err(|e| e.to_string())?,
             };
 
-            let options = ConnectOptions { block_async_connect: true, strategy: ConnectStrategy::Fallback, url : Some(url), ..Default::default() };
+            let options = ConnectOptions {
+                block_async_connect: true,
+                strategy: ConnectStrategy::Fallback,
+                url: Some(url),
+                ..Default::default()
+            };
             wrpc_client.connect(Some(options)).await.map_err(|e| e.to_string())?;
         } else {
             terrorln!(ctx, "Unable to connect with non-wRPC client");

--- a/cli/src/modules/connect.rs
+++ b/cli/src/modules/connect.rs
@@ -1,4 +1,5 @@
 use crate::imports::*;
+use kaspa_wrpc_client::Resolver;
 
 #[derive(Default, Handler)]
 #[help("Connect to a Kaspa network")]
@@ -9,11 +10,23 @@ impl Connect {
         let ctx = ctx.clone().downcast_arc::<KaspaCli>()?;
         if let Some(wrpc_client) = ctx.wallet().try_wrpc_client().as_ref() {
             let url = argv.first().cloned().or_else(|| ctx.wallet().settings().get(WalletSettings::Server));
-            let network_type = ctx.wallet().network_id()?;
-            let url = url
-                .map(|url| wrpc_client.parse_url_with_network_type(url, network_type.into()).map_err(|e| e.to_string()))
-                .transpose()?;
-            let options = ConnectOptions { block_async_connect: true, strategy: ConnectStrategy::Fallback, url, ..Default::default() };
+            let network_id = ctx.wallet().network_id()?;
+
+            let url = match url.as_deref() {
+                Some("public") => {
+                    tprintln!(ctx, "Connecting to a public node");
+                    Resolver::default().fetch(WrpcEncoding::Borsh, network_id).await.map_err(|e| e.to_string())?.url
+                },
+                None => {
+                    tprintln!(ctx, "No server set, connecting to a public node");
+                    Resolver::default().fetch(WrpcEncoding::Borsh, network_id).await.map_err(|e| e.to_string())?.url
+                },
+                Some(url) => {
+                    wrpc_client.parse_url_with_network_type(url.to_string(), network_id.into()).map_err(|e| e.to_string())?
+                },
+            };
+
+            let options = ConnectOptions { block_async_connect: true, strategy: ConnectStrategy::Fallback, url : Some(url), ..Default::default() };
             wrpc_client.connect(Some(options)).await.map_err(|e| e.to_string())?;
         } else {
             terrorln!(ctx, "Unable to connect with non-wRPC client");

--- a/notify/src/address/tracker.rs
+++ b/notify/src/address/tracker.rs
@@ -276,7 +276,7 @@ impl Inner {
             Self::MAX_ADDRESS_UPPER_BOUND
         );
         let max_addresses = max_addresses.unwrap_or(Self::DEFAULT_MAX_ADDRESSES);
-        info!("Memory configuration: UTXO changed events wil be tracked for at most {} addresses", max_addresses);
+        debug!("Memory configuration: UTXO changed events wil be tracked for at most {} addresses", max_addresses);
 
         let script_pub_keys = IndexMap::with_capacity(capacity);
         debug!("Creating an address tracker with a capacity of {}", script_pub_keys.capacity());

--- a/notify/src/address/tracker.rs
+++ b/notify/src/address/tracker.rs
@@ -3,7 +3,7 @@ use indexmap::{map::Entry, IndexMap};
 use itertools::Itertools;
 use kaspa_addresses::{Address, Prefix};
 use kaspa_consensus_core::tx::ScriptPublicKey;
-use kaspa_core::{debug, info, trace};
+use kaspa_core::{debug, trace};
 use kaspa_txscript::{extract_script_pub_key_address, pay_to_address_script};
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::{

--- a/wallet/core/src/settings.rs
+++ b/wallet/core/src/settings.rs
@@ -27,7 +27,7 @@ pub enum WalletSettings {
 #[async_trait]
 impl DefaultSettings for WalletSettings {
     async fn defaults() -> Vec<(Self, Value)> {
-        vec![(Self::Server, to_value("127.0.0.1").unwrap()), (Self::Wallet, to_value("kaspa").unwrap())]
+        vec![(Self::Server, to_value("public").unwrap()), (Self::Wallet, to_value("kaspa").unwrap())]
     }
 }
 

--- a/wallet/core/src/utxo/processor.rs
+++ b/wallet/core/src/utxo/processor.rs
@@ -682,8 +682,6 @@ impl UtxoProcessor {
                 }
             }
 
-            log_info!("utxo processing task existing");
-
             // handle power down on rpc channel that remains connected
             if this.is_connected() {
                 this.handle_disconnect().await.unwrap_or_else(|err| log_error!("{err}"));


### PR DESCRIPTION
By default CLI `server` setting is now set to `public` instead of `127.0.0.1`.  If `server` is `public` the `connect` command will use the `Resolver` to get a community-maintained public node address.

- Adding support for `public` value in the server URL.