### PR TITLE
WIP - decoupling RPC type aliases

### DIFF
--- a/consensus/core/src/header.rs
+++ b/consensus/core/src/header.rs
@@ -92,6 +92,12 @@ impl Header {
     }
 }
 
+impl AsRef<Header> for Header {
+    fn as_ref(&self) -> &Header {
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rothschild/src/main.rs
+++ b/rothschild/src/main.rs
@@ -13,7 +13,7 @@ use kaspa_consensus_core::{
 use kaspa_core::{info, kaspad_env::version, time::unix_now, warn};
 use kaspa_grpc_client::{ClientPool, GrpcClient};
 use kaspa_notify::subscription::context::SubscriptionContext;
-use kaspa_rpc_core::{api::rpc::RpcApi, notify::mode::NotificationMode};
+use kaspa_rpc_core::{api::rpc::RpcApi, notify::mode::NotificationMode, RpcUtxoEntry};
 use kaspa_txscript::pay_to_address_script;
 use parking_lot::Mutex;
 use rayon::prelude::*;
@@ -323,7 +323,7 @@ async fn populate_pending_outpoints_from_mempool(
     for entry in entries {
         for entry in entry.sending {
             for input in entry.transaction.inputs {
-                pending_outpoints.insert(input.previous_outpoint, now);
+                pending_outpoints.insert(input.previous_outpoint.into(), now);
             }
         }
     }
@@ -337,20 +337,20 @@ async fn fetch_spendable_utxos(
 ) -> Vec<(TransactionOutpoint, UtxoEntry)> {
     let resp = rpc_client.get_utxos_by_addresses(vec![kaspa_addr]).await.unwrap();
     let dag_info = rpc_client.get_block_dag_info().await.unwrap();
-    let mut utxos = Vec::with_capacity(resp.len());
-    for resp_entry in resp
-        .into_iter()
-        .filter(|resp_entry| is_utxo_spendable(&resp_entry.utxo_entry, dag_info.virtual_daa_score, coinbase_maturity))
+
+    let mut utxos = resp.into_iter()
+        .filter(|entry| {
+            is_utxo_spendable(&entry.utxo_entry, dag_info.virtual_daa_score, coinbase_maturity)
+        })
+        .map(|entry| (TransactionOutpoint::from(entry.outpoint), UtxoEntry::from(entry.utxo_entry)))
         // Eliminates UTXOs we already tried to spend so we don't try to spend them again in this period
-        .filter(|utxo| !pending.contains_key(&utxo.outpoint))
-    {
-        utxos.push((resp_entry.outpoint, resp_entry.utxo_entry));
-    }
+        .filter(|(outpoint,_)| !pending.contains_key(outpoint))
+        .collect::<Vec<_>>();
     utxos.sort_by(|a, b| b.1.amount.cmp(&a.1.amount));
     utxos
 }
 
-fn is_utxo_spendable(entry: &UtxoEntry, virtual_daa_score: u64, coinbase_maturity: u64) -> bool {
+fn is_utxo_spendable(entry: &RpcUtxoEntry, virtual_daa_score: u64, coinbase_maturity: u64) -> bool {
     let needed_confs = if !entry.is_coinbase {
         10
     } else {

--- a/rpc/core/Cargo.toml
+++ b/rpc/core/Cargo.toml
@@ -42,6 +42,7 @@ hex.workspace = true
 js-sys.workspace = true
 log.workspace = true
 paste.workspace = true
+rand.workspace = true
 serde-wasm-bindgen.workspace = true
 serde.workspace = true
 smallvec.workspace = true
@@ -51,7 +52,6 @@ wasm-bindgen.workspace = true
 workflow-core.workspace = true
 workflow-serializer.workspace = true
 workflow-wasm.workspace = true
-rand.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/rpc/core/src/convert/block.rs
+++ b/rpc/core/src/convert/block.rs
@@ -10,7 +10,7 @@ use kaspa_consensus_core::block::{Block, MutableBlock};
 impl From<&Block> for RpcBlock {
     fn from(item: &Block) -> Self {
         Self {
-            header: (*item.header).clone(),
+            header: item.header.as_ref().into(),
             transactions: item.transactions.iter().map(RpcTransaction::from).collect(),
             // TODO: Implement a populating process inspired from kaspad\app\rpc\rpccontext\verbosedata.go
             verbose_data: None,
@@ -21,7 +21,7 @@ impl From<&Block> for RpcBlock {
 impl From<&MutableBlock> for RpcBlock {
     fn from(item: &MutableBlock) -> Self {
         Self {
-            header: item.header.clone(),
+            header: item.header.as_ref().into(),
             transactions: item.transactions.iter().map(RpcTransaction::from).collect(),
             verbose_data: None,
         }
@@ -36,7 +36,7 @@ impl TryFrom<&RpcBlock> for Block {
     type Error = RpcError;
     fn try_from(item: &RpcBlock) -> RpcResult<Self> {
         Ok(Self {
-            header: Arc::new(item.header.clone()),
+            header: Arc::new(item.header.as_ref().into()),
             transactions: Arc::new(
                 item.transactions
                     .iter()

--- a/rpc/core/src/convert/tx.rs
+++ b/rpc/core/src/convert/tx.rs
@@ -36,7 +36,7 @@ impl From<&TransactionOutput> for RpcTransactionOutput {
 impl From<&TransactionInput> for RpcTransactionInput {
     fn from(item: &TransactionInput) -> Self {
         Self {
-            previous_outpoint: item.previous_outpoint,
+            previous_outpoint: item.previous_outpoint.into(),
             signature_script: item.signature_script.clone(),
             sequence: item.sequence,
             sig_op_count: item.sig_op_count,
@@ -83,6 +83,6 @@ impl TryFrom<&RpcTransactionOutput> for TransactionOutput {
 impl TryFrom<&RpcTransactionInput> for TransactionInput {
     type Error = RpcError;
     fn try_from(item: &RpcTransactionInput) -> RpcResult<Self> {
-        Ok(Self::new(item.previous_outpoint, item.signature_script.clone(), item.sequence, item.sig_op_count))
+        Ok(Self::new(item.previous_outpoint.into(), item.signature_script.clone(), item.sequence, item.sig_op_count))
     }
 }

--- a/rpc/core/src/convert/utxo.rs
+++ b/rpc/core/src/convert/utxo.rs
@@ -1,6 +1,6 @@
+use crate::RpcUtxoEntry;
 use crate::RpcUtxosByAddressesEntry;
 use kaspa_addresses::Prefix;
-use kaspa_consensus_core::tx::UtxoEntry;
 use kaspa_index_core::indexed_utxos::UtxoSetByScriptPublicKey;
 use kaspa_txscript::extract_script_pub_key_address;
 
@@ -16,8 +16,8 @@ pub fn utxo_set_into_rpc(item: &UtxoSetByScriptPublicKey, prefix: Option<Prefix>
                 .iter()
                 .map(|(outpoint, entry)| RpcUtxosByAddressesEntry {
                     address: address.clone(),
-                    outpoint: *outpoint,
-                    utxo_entry: UtxoEntry::new(entry.amount, script_public_key.clone(), entry.block_daa_score, entry.is_coinbase),
+                    outpoint: (*outpoint).into(),
+                    utxo_entry: RpcUtxoEntry::new(entry.amount, script_public_key.clone(), entry.block_daa_score, entry.is_coinbase),
                 })
                 .collect::<Vec<_>>()
         })

--- a/rpc/core/src/model/address.rs
+++ b/rpc/core/src/model/address.rs
@@ -1,11 +1,11 @@
 use crate::{RpcTransactionOutpoint, RpcUtxoEntry};
-use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
+use workflow_serializer::prelude::*;
 
 pub type RpcAddress = kaspa_addresses::Address;
 
 /// Represents a UTXO entry of an address returned by the `GetUtxosByAddresses` RPC.
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcUtxosByAddressesEntry {
     pub address: Option<RpcAddress>,
@@ -13,12 +13,44 @@ pub struct RpcUtxosByAddressesEntry {
     pub utxo_entry: RpcUtxoEntry,
 }
 
+impl Serializer for RpcUtxosByAddressesEntry {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        store!(u8, &1, writer)?; // version
+        store!(Option<RpcAddress>, &self.address, writer)?;
+        serialize!(RpcTransactionOutpoint, &self.outpoint, writer)?;
+        serialize!(RpcUtxoEntry, &self.utxo_entry, writer)
+    }
+
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let _version: u8 = load!(u8, reader)?;
+        let address = load!(Option<RpcAddress>, reader)?;
+        let outpoint = deserialize!(RpcTransactionOutpoint, reader)?;
+        let utxo_entry = deserialize!(RpcUtxoEntry, reader)?;
+        Ok(Self { address, outpoint, utxo_entry })
+    }
+}
+
 /// Represents a balance of an address returned by the `GetBalancesByAddresses` RPC.
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcBalancesByAddressesEntry {
     pub address: RpcAddress,
 
     /// Balance of `address` if available
     pub balance: Option<u64>,
+}
+
+impl Serializer for RpcBalancesByAddressesEntry {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        store!(u8, &1, writer)?; // version
+        store!(RpcAddress, &self.address, writer)?;
+        store!(Option<u64>, &self.balance, writer)
+    }
+
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let _version: u8 = load!(u8, reader)?;
+        let address = load!(RpcAddress, reader)?;
+        let balance = load!(Option<u64>, reader)?;
+        Ok(Self { address, balance })
+    }
 }

--- a/rpc/core/src/model/block.rs
+++ b/rpc/core/src/model/block.rs
@@ -1,8 +1,8 @@
 use crate::prelude::{RpcHash, RpcHeader, RpcTransaction};
-use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
+use workflow_serializer::prelude::*;
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcBlock {
     pub header: RpcHeader,
@@ -10,7 +10,27 @@ pub struct RpcBlock {
     pub verbose_data: Option<RpcBlockVerboseData>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+impl Serializer for RpcBlock {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        store!(u32, &1, writer)?;
+        serialize!(RpcHeader, &self.header, writer)?;
+        serialize!(Vec<RpcTransaction>, &self.transactions, writer)?;
+        serialize!(Option<RpcBlockVerboseData>, &self.verbose_data, writer)?;
+
+        Ok(())
+    }
+
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let _version = load!(u32, reader)?;
+        let header = deserialize!(RpcHeader, reader)?;
+        let transactions = deserialize!(Vec<RpcTransaction>, reader)?;
+        let verbose_data = deserialize!(Option<RpcBlockVerboseData>, reader)?;
+
+        Ok(Self { header, transactions, verbose_data })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcBlockVerboseData {
     pub hash: RpcHash,
@@ -23,6 +43,51 @@ pub struct RpcBlockVerboseData {
     pub merge_set_blues_hashes: Vec<RpcHash>,
     pub merge_set_reds_hashes: Vec<RpcHash>,
     pub is_chain_block: bool,
+}
+
+impl Serializer for RpcBlockVerboseData {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        store!(u8, &1, writer)?;
+        store!(RpcHash, &self.hash, writer)?;
+        store!(f64, &self.difficulty, writer)?;
+        store!(RpcHash, &self.selected_parent_hash, writer)?;
+        store!(Vec<RpcHash>, &self.transaction_ids, writer)?;
+        store!(bool, &self.is_header_only, writer)?;
+        store!(u64, &self.blue_score, writer)?;
+        store!(Vec<RpcHash>, &self.children_hashes, writer)?;
+        store!(Vec<RpcHash>, &self.merge_set_blues_hashes, writer)?;
+        store!(Vec<RpcHash>, &self.merge_set_reds_hashes, writer)?;
+        store!(bool, &self.is_chain_block, writer)?;
+
+        Ok(())
+    }
+
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let _version = load!(u8, reader)?;
+        let hash = load!(RpcHash, reader)?;
+        let difficulty = load!(f64, reader)?;
+        let selected_parent_hash = load!(RpcHash, reader)?;
+        let transaction_ids = load!(Vec<RpcHash>, reader)?;
+        let is_header_only = load!(bool, reader)?;
+        let blue_score = load!(u64, reader)?;
+        let children_hashes = load!(Vec<RpcHash>, reader)?;
+        let merge_set_blues_hashes = load!(Vec<RpcHash>, reader)?;
+        let merge_set_reds_hashes = load!(Vec<RpcHash>, reader)?;
+        let is_chain_block = load!(bool, reader)?;
+
+        Ok(Self {
+            hash,
+            difficulty,
+            selected_parent_hash,
+            transaction_ids,
+            is_header_only,
+            blue_score,
+            children_hashes,
+            merge_set_blues_hashes,
+            merge_set_reds_hashes,
+            is_chain_block,
+        })
+    }
 }
 
 cfg_if::cfg_if! {

--- a/rpc/core/src/model/header.rs
+++ b/rpc/core/src/model/header.rs
@@ -1,1 +1,179 @@
-pub type RpcHeader = kaspa_consensus_core::header::Header;
+// pub type RpcHeader = kaspa_consensus_core::header::Header;
+use borsh::{BorshDeserialize, BorshSerialize};
+use kaspa_consensus_core::header::Header;
+use kaspa_consensus_core::BlueWorkType;
+use kaspa_hashes::Hash;
+use serde::{Deserialize, Serialize};
+use workflow_serializer::prelude::*;
+
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcHeader {
+    /// Cached hash
+    pub hash: Hash,
+    pub version: u16,
+    pub parents_by_level: Vec<Vec<Hash>>,
+    pub hash_merkle_root: Hash,
+    pub accepted_id_merkle_root: Hash,
+    pub utxo_commitment: Hash,
+    /// Timestamp is in milliseconds
+    pub timestamp: u64,
+    pub bits: u32,
+    pub nonce: u64,
+    pub daa_score: u64,
+    pub blue_work: BlueWorkType,
+    pub blue_score: u64,
+    pub pruning_point: Hash,
+}
+
+impl RpcHeader {
+    pub fn direct_parents(&self) -> &[Hash] {
+        if self.parents_by_level.is_empty() {
+            &[]
+        } else {
+            &self.parents_by_level[0]
+        }
+    }
+}
+
+impl AsRef<RpcHeader> for RpcHeader {
+    fn as_ref(&self) -> &RpcHeader {
+        self
+    }
+}
+
+impl From<Header> for RpcHeader {
+    fn from(header: Header) -> Self {
+        Self {
+            hash: header.hash,
+            version: header.version,
+            parents_by_level: header.parents_by_level,
+            hash_merkle_root: header.hash_merkle_root,
+            accepted_id_merkle_root: header.accepted_id_merkle_root,
+            utxo_commitment: header.utxo_commitment,
+            timestamp: header.timestamp,
+            bits: header.bits,
+            nonce: header.nonce,
+            daa_score: header.daa_score,
+            blue_work: header.blue_work,
+            blue_score: header.blue_score,
+            pruning_point: header.pruning_point,
+        }
+    }
+}
+
+impl From<&Header> for RpcHeader {
+    fn from(header: &Header) -> Self {
+        Self {
+            hash: header.hash,
+            version: header.version,
+            parents_by_level: header.parents_by_level.clone(),
+            hash_merkle_root: header.hash_merkle_root,
+            accepted_id_merkle_root: header.accepted_id_merkle_root,
+            utxo_commitment: header.utxo_commitment,
+            timestamp: header.timestamp,
+            bits: header.bits,
+            nonce: header.nonce,
+            daa_score: header.daa_score,
+            blue_work: header.blue_work,
+            blue_score: header.blue_score,
+            pruning_point: header.pruning_point,
+        }
+    }
+}
+
+impl From<RpcHeader> for Header {
+    fn from(header: RpcHeader) -> Self {
+        Self {
+            hash: header.hash,
+            version: header.version,
+            parents_by_level: header.parents_by_level,
+            hash_merkle_root: header.hash_merkle_root,
+            accepted_id_merkle_root: header.accepted_id_merkle_root,
+            utxo_commitment: header.utxo_commitment,
+            timestamp: header.timestamp,
+            bits: header.bits,
+            nonce: header.nonce,
+            daa_score: header.daa_score,
+            blue_work: header.blue_work,
+            blue_score: header.blue_score,
+            pruning_point: header.pruning_point,
+        }
+    }
+}
+
+impl From<&RpcHeader> for Header {
+    fn from(header: &RpcHeader) -> Self {
+        Self {
+            hash: header.hash,
+            version: header.version,
+            parents_by_level: header.parents_by_level.clone(),
+            hash_merkle_root: header.hash_merkle_root,
+            accepted_id_merkle_root: header.accepted_id_merkle_root,
+            utxo_commitment: header.utxo_commitment,
+            timestamp: header.timestamp,
+            bits: header.bits,
+            nonce: header.nonce,
+            daa_score: header.daa_score,
+            blue_work: header.blue_work,
+            blue_score: header.blue_score,
+            pruning_point: header.pruning_point,
+        }
+    }
+}
+
+impl Serializer for RpcHeader {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        store!(u32, &1, writer)?;
+
+        store!(Hash, &self.hash, writer)?;
+        store!(u16, &self.version, writer)?;
+        store!(Vec<Vec<Hash>>, &self.parents_by_level, writer)?;
+        store!(Hash, &self.hash_merkle_root, writer)?;
+        store!(Hash, &self.accepted_id_merkle_root, writer)?;
+        store!(Hash, &self.utxo_commitment, writer)?;
+        store!(u64, &self.timestamp, writer)?;
+        store!(u32, &self.bits, writer)?;
+        store!(u64, &self.nonce, writer)?;
+        store!(u64, &self.daa_score, writer)?;
+        store!(BlueWorkType, &self.blue_work, writer)?;
+        store!(u64, &self.blue_score, writer)?;
+        store!(Hash, &self.pruning_point, writer)?;
+
+        Ok(())
+    }
+
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let _version = load!(u32, reader)?;
+
+        let hash = load!(Hash, reader)?;
+        let version = load!(u16, reader)?;
+        let parents_by_level = load!(Vec<Vec<Hash>>, reader)?;
+        let hash_merkle_root = load!(Hash, reader)?;
+        let accepted_id_merkle_root = load!(Hash, reader)?;
+        let utxo_commitment = load!(Hash, reader)?;
+        let timestamp = load!(u64, reader)?;
+        let bits = load!(u32, reader)?;
+        let nonce = load!(u64, reader)?;
+        let daa_score = load!(u64, reader)?;
+        let blue_work = load!(BlueWorkType, reader)?;
+        let blue_score = load!(u64, reader)?;
+        let pruning_point = load!(Hash, reader)?;
+
+        Ok(Self {
+            hash,
+            version,
+            parents_by_level,
+            hash_merkle_root,
+            accepted_id_merkle_root,
+            utxo_commitment,
+            timestamp,
+            bits,
+            nonce,
+            daa_score,
+            blue_work,
+            blue_score,
+            pruning_point,
+        })
+    }
+}

--- a/rpc/core/src/model/mempool.rs
+++ b/rpc/core/src/model/mempool.rs
@@ -1,9 +1,9 @@
 use super::RpcAddress;
 use super::RpcTransaction;
-use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
+use workflow_serializer::prelude::*;
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RpcMempoolEntry {
     pub fee: u64,
     pub transaction: RpcTransaction,
@@ -16,7 +16,22 @@ impl RpcMempoolEntry {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+impl Serializer for RpcMempoolEntry {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        store!(u64, &self.fee, writer)?;
+        serialize!(RpcTransaction, &self.transaction, writer)?;
+        store!(bool, &self.is_orphan, writer)
+    }
+
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let fee = load!(u64, reader)?;
+        let transaction = deserialize!(RpcTransaction, reader)?;
+        let is_orphan = load!(bool, reader)?;
+        Ok(Self { fee, transaction, is_orphan })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RpcMempoolEntryByAddress {
     pub address: RpcAddress,
     pub sending: Vec<RpcMempoolEntry>,
@@ -26,6 +41,21 @@ pub struct RpcMempoolEntryByAddress {
 impl RpcMempoolEntryByAddress {
     pub fn new(address: RpcAddress, sending: Vec<RpcMempoolEntry>, receiving: Vec<RpcMempoolEntry>) -> Self {
         Self { address, sending, receiving }
+    }
+}
+
+impl Serializer for RpcMempoolEntryByAddress {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        store!(RpcAddress, &self.address, writer)?;
+        serialize!(Vec<RpcMempoolEntry>, &self.sending, writer)?;
+        serialize!(Vec<RpcMempoolEntry>, &self.receiving, writer)
+    }
+
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let address = load!(RpcAddress, reader)?;
+        let sending = deserialize!(Vec<RpcMempoolEntry>, reader)?;
+        let receiving = deserialize!(Vec<RpcMempoolEntry>, reader)?;
+        Ok(Self { address, sending, receiving })
     }
 }
 

--- a/rpc/core/src/model/message.rs
+++ b/rpc/core/src/model/message.rs
@@ -32,7 +32,7 @@ impl SubmitBlockRequest {
 impl Serializer for SubmitBlockRequest {
     fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
         store!(u32, &1, writer)?;
-        store!(RpcBlock, &self.block, writer)?;
+        serialize!(RpcBlock, &self.block, writer)?;
         store!(bool, &self.allow_non_daa_blocks, writer)?;
 
         Ok(())
@@ -40,7 +40,7 @@ impl Serializer for SubmitBlockRequest {
 
     fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
         let _version = load!(u32, reader)?;
-        let block = load!(RpcBlock, reader)?;
+        let block = deserialize!(RpcBlock, reader)?;
         let allow_non_daa_blocks = load!(bool, reader)?;
 
         Ok(Self { block, allow_non_daa_blocks })
@@ -157,7 +157,7 @@ pub struct GetBlockTemplateResponse {
 impl Serializer for GetBlockTemplateResponse {
     fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
         store!(u32, &1, writer)?;
-        store!(RpcBlock, &self.block, writer)?;
+        serialize!(RpcBlock, &self.block, writer)?;
         store!(bool, &self.is_synced, writer)?;
 
         Ok(())
@@ -165,7 +165,7 @@ impl Serializer for GetBlockTemplateResponse {
 
     fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
         let _version = load!(u32, reader)?;
-        let block = load!(RpcBlock, reader)?;
+        let block = deserialize!(RpcBlock, reader)?;
         let is_synced = load!(bool, reader)?;
 
         Ok(Self { block, is_synced })
@@ -215,14 +215,14 @@ pub struct GetBlockResponse {
 impl Serializer for GetBlockResponse {
     fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
         store!(u32, &1, writer)?;
-        store!(RpcBlock, &self.block, writer)?;
+        serialize!(RpcBlock, &self.block, writer)?;
 
         Ok(())
     }
 
     fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
         let _version = load!(u32, reader)?;
-        let block = load!(RpcBlock, reader)?;
+        let block = deserialize!(RpcBlock, reader)?;
 
         Ok(Self { block })
     }
@@ -464,13 +464,13 @@ impl GetMempoolEntryResponse {
 impl Serializer for GetMempoolEntryResponse {
     fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
         store!(u32, &1, writer)?;
-        store!(RpcMempoolEntry, &self.mempool_entry, writer)?;
+        serialize!(RpcMempoolEntry, &self.mempool_entry, writer)?;
         Ok(())
     }
 
     fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
         let _version = load!(u32, reader)?;
-        let mempool_entry = load!(RpcMempoolEntry, reader)?;
+        let mempool_entry = deserialize!(RpcMempoolEntry, reader)?;
         Ok(Self { mempool_entry })
     }
 }
@@ -522,13 +522,13 @@ impl GetMempoolEntriesResponse {
 impl Serializer for GetMempoolEntriesResponse {
     fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
         store!(u32, &1, writer)?;
-        store!(Vec<RpcMempoolEntry>, &self.mempool_entries, writer)?;
+        serialize!(Vec<RpcMempoolEntry>, &self.mempool_entries, writer)?;
         Ok(())
     }
 
     fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
         let _version = load!(u32, reader)?;
-        let mempool_entries = load!(Vec<RpcMempoolEntry>, reader)?;
+        let mempool_entries = deserialize!(Vec<RpcMempoolEntry>, reader)?;
         Ok(Self { mempool_entries })
     }
 }
@@ -639,7 +639,7 @@ impl Serializer for SubmitTransactionRequest {
     fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
         store!(u32, &1, writer)?;
         // TODO
-        store!(RpcTransaction, &self.transaction, writer)?;
+        serialize!(RpcTransaction, &self.transaction, writer)?;
         store!(bool, &self.allow_orphan, writer)?;
 
         Ok(())
@@ -647,7 +647,7 @@ impl Serializer for SubmitTransactionRequest {
 
     fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
         let _version = load!(u32, reader)?;
-        let transaction = load!(RpcTransaction, reader)?;
+        let transaction = deserialize!(RpcTransaction, reader)?;
         let allow_orphan = load!(bool, reader)?;
 
         Ok(Self { transaction, allow_orphan })
@@ -858,7 +858,7 @@ impl Serializer for GetBlocksResponse {
     fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
         store!(u32, &1, writer)?;
         store!(Vec<RpcHash>, &self.block_hashes, writer)?;
-        store!(Vec<RpcBlock>, &self.blocks, writer)?;
+        serialize!(Vec<RpcBlock>, &self.blocks, writer)?;
 
         Ok(())
     }
@@ -866,7 +866,7 @@ impl Serializer for GetBlocksResponse {
     fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
         let _version = load!(u32, reader)?;
         let block_hashes = load!(Vec<RpcHash>, reader)?;
-        let blocks = load!(Vec<RpcBlock>, reader)?;
+        let blocks = deserialize!(Vec<RpcBlock>, reader)?;
 
         Ok(Self { block_hashes, blocks })
     }
@@ -1231,14 +1231,14 @@ impl GetBalancesByAddressesResponse {
 impl Serializer for GetBalancesByAddressesResponse {
     fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
         store!(u32, &1, writer)?;
-        store!(Vec<RpcBalancesByAddressesEntry>, &self.entries, writer)?;
+        serialize!(Vec<RpcBalancesByAddressesEntry>, &self.entries, writer)?;
 
         Ok(())
     }
 
     fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
         let _version = load!(u32, reader)?;
-        let entries = load!(Vec<RpcBalancesByAddressesEntry>, reader)?;
+        let entries = deserialize!(Vec<RpcBalancesByAddressesEntry>, reader)?;
 
         Ok(Self { entries })
     }
@@ -1331,14 +1331,14 @@ impl GetUtxosByAddressesResponse {
 impl Serializer for GetUtxosByAddressesResponse {
     fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
         store!(u32, &1, writer)?;
-        store!(Vec<RpcUtxosByAddressesEntry>, &self.entries, writer)?;
+        serialize!(Vec<RpcUtxosByAddressesEntry>, &self.entries, writer)?;
 
         Ok(())
     }
 
     fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
         let _version = load!(u32, reader)?;
-        let entries = load!(Vec<RpcUtxosByAddressesEntry>, reader)?;
+        let entries = deserialize!(Vec<RpcUtxosByAddressesEntry>, reader)?;
 
         Ok(Self { entries })
     }
@@ -1541,14 +1541,14 @@ impl GetMempoolEntriesByAddressesResponse {
 impl Serializer for GetMempoolEntriesByAddressesResponse {
     fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
         store!(u32, &1, writer)?;
-        store!(Vec<RpcMempoolEntryByAddress>, &self.entries, writer)?;
+        serialize!(Vec<RpcMempoolEntryByAddress>, &self.entries, writer)?;
 
         Ok(())
     }
 
     fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
         let _version = load!(u32, reader)?;
-        let entries = load!(Vec<RpcMempoolEntryByAddress>, reader)?;
+        let entries = deserialize!(Vec<RpcMempoolEntryByAddress>, reader)?;
 
         Ok(Self { entries })
     }
@@ -2153,13 +2153,13 @@ pub struct BlockAddedNotification {
 impl Serializer for BlockAddedNotification {
     fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
         store!(u32, &1, writer)?;
-        store!(RpcBlock, &self.block, writer)?;
+        serialize!(RpcBlock, &self.block, writer)?;
         Ok(())
     }
 
     fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
         let _version = load!(u32, reader)?;
-        let block = load!(RpcBlock, reader)?;
+        let block = deserialize!(RpcBlock, reader)?;
         Ok(Self { block: block.into() })
     }
 }
@@ -2480,15 +2480,15 @@ impl UtxosChangedNotification {
 impl Serializer for UtxosChangedNotification {
     fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
         store!(u32, &1, writer)?;
-        store!(Vec<RpcUtxosByAddressesEntry>, &self.added, writer)?;
-        store!(Vec<RpcUtxosByAddressesEntry>, &self.removed, writer)?;
+        serialize!(Vec<RpcUtxosByAddressesEntry>, &self.added, writer)?;
+        serialize!(Vec<RpcUtxosByAddressesEntry>, &self.removed, writer)?;
         Ok(())
     }
 
     fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
         let _version = load!(u32, reader)?;
-        let added = load!(Vec<RpcUtxosByAddressesEntry>, reader)?;
-        let removed = load!(Vec<RpcUtxosByAddressesEntry>, reader)?;
+        let added = deserialize!(Vec<RpcUtxosByAddressesEntry>, reader)?;
+        let removed = deserialize!(Vec<RpcUtxosByAddressesEntry>, reader)?;
         Ok(Self { added: added.into(), removed: removed.into() })
     }
 }

--- a/rpc/core/src/model/tests.rs
+++ b/rpc/core/src/model/tests.rs
@@ -4,10 +4,9 @@ mod mockery {
     use crate::{model::*, RpcScriptClass};
     use kaspa_addresses::{Prefix, Version};
     use kaspa_consensus_core::api::BlockCount;
-    use kaspa_consensus_core::header::Header;
     use kaspa_consensus_core::network::NetworkType;
     use kaspa_consensus_core::subnets::SubnetworkId;
-    use kaspa_consensus_core::tx::{ScriptPublicKey, TransactionOutpoint, UtxoEntry};
+    use kaspa_consensus_core::tx::ScriptPublicKey;
     use kaspa_hashes::Hash;
     use kaspa_math::Uint192;
     use kaspa_notify::subscription::Command;
@@ -136,9 +135,9 @@ mod mockery {
         }
     }
 
-    impl Mock for Header {
+    impl Mock for RpcHeader {
         fn mock() -> Self {
-            Header {
+            RpcHeader {
                 version: mock(),
                 timestamp: mock(),
                 bits: mock(),
@@ -297,15 +296,15 @@ mod mockery {
         }
     }
 
-    impl Mock for UtxoEntry {
+    impl Mock for RpcUtxoEntry {
         fn mock() -> Self {
-            UtxoEntry { amount: mock(), script_public_key: mock(), block_daa_score: mock(), is_coinbase: true }
+            RpcUtxoEntry { amount: mock(), script_public_key: mock(), block_daa_score: mock(), is_coinbase: true }
         }
     }
 
-    impl Mock for TransactionOutpoint {
+    impl Mock for RpcTransactionOutpoint {
         fn mock() -> Self {
-            TransactionOutpoint { transaction_id: mock(), index: mock() }
+            RpcTransactionOutpoint { transaction_id: mock(), index: mock() }
         }
     }
 

--- a/rpc/core/src/model/tx.rs
+++ b/rpc/core/src/model/tx.rs
@@ -1,9 +1,12 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use kaspa_addresses::Address;
 use kaspa_consensus_core::tx::{
-    ScriptPublicKey, ScriptVec, TransactionId, TransactionInput, TransactionOutpoint, TransactionOutput, UtxoEntry,
+    ScriptPublicKey, ScriptVec, TransactionId, TransactionIndexType, TransactionInput, TransactionOutpoint, TransactionOutput,
+    UtxoEntry,
 };
+use kaspa_utils::serde_bytes_fixed_ref;
 use serde::{Deserialize, Serialize};
+use workflow_serializer::prelude::*;
 
 use crate::prelude::{RpcHash, RpcScriptClass, RpcSubnetworkId};
 
@@ -12,13 +15,120 @@ pub type RpcTransactionId = TransactionId;
 
 pub type RpcScriptVec = ScriptVec;
 pub type RpcScriptPublicKey = ScriptPublicKey;
-pub type RpcUtxoEntry = UtxoEntry;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcUtxoEntry {
+    pub amount: u64,
+    pub script_public_key: ScriptPublicKey,
+    pub block_daa_score: u64,
+    pub is_coinbase: bool,
+}
+
+impl RpcUtxoEntry {
+    pub fn new(amount: u64, script_public_key: ScriptPublicKey, block_daa_score: u64, is_coinbase: bool) -> Self {
+        Self { amount, script_public_key, block_daa_score, is_coinbase }
+    }
+}
+
+impl From<UtxoEntry> for RpcUtxoEntry {
+    fn from(entry: UtxoEntry) -> Self {
+        Self {
+            amount: entry.amount,
+            script_public_key: entry.script_public_key,
+            block_daa_score: entry.block_daa_score,
+            is_coinbase: entry.is_coinbase,
+        }
+    }
+}
+
+impl From<RpcUtxoEntry> for UtxoEntry {
+    fn from(entry: RpcUtxoEntry) -> Self {
+        Self {
+            amount: entry.amount,
+            script_public_key: entry.script_public_key,
+            block_daa_score: entry.block_daa_score,
+            is_coinbase: entry.is_coinbase,
+        }
+    }
+}
+
+impl Serializer for RpcUtxoEntry {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        store!(u8, &1, writer)?;
+        store!(u64, &self.amount, writer)?;
+        store!(ScriptPublicKey, &self.script_public_key, writer)?;
+        store!(u64, &self.block_daa_score, writer)?;
+        store!(bool, &self.is_coinbase, writer)?;
+
+        Ok(())
+    }
+
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let _version = load!(u8, reader)?;
+        let amount = load!(u64, reader)?;
+        let script_public_key = load!(ScriptPublicKey, reader)?;
+        let block_daa_score = load!(u64, reader)?;
+        let is_coinbase = load!(bool, reader)?;
+
+        Ok(Self { amount, script_public_key, block_daa_score, is_coinbase })
+    }
+}
 
 /// Represents a Kaspa transaction outpoint
-pub type RpcTransactionOutpoint = TransactionOutpoint;
+#[derive(Eq, Hash, PartialEq, Debug, Copy, Clone, Serialize, Deserialize)]
+pub struct RpcTransactionOutpoint {
+    #[serde(with = "serde_bytes_fixed_ref")]
+    pub transaction_id: TransactionId,
+    pub index: TransactionIndexType,
+}
+
+impl From<TransactionOutpoint> for RpcTransactionOutpoint {
+    fn from(outpoint: TransactionOutpoint) -> Self {
+        Self { transaction_id: outpoint.transaction_id, index: outpoint.index }
+    }
+}
+
+impl From<RpcTransactionOutpoint> for TransactionOutpoint {
+    fn from(outpoint: RpcTransactionOutpoint) -> Self {
+        Self { transaction_id: outpoint.transaction_id, index: outpoint.index }
+    }
+}
+
+impl From<kaspa_consensus_client::TransactionOutpoint> for RpcTransactionOutpoint {
+    fn from(outpoint: kaspa_consensus_client::TransactionOutpoint) -> Self {
+        TransactionOutpoint::from(outpoint).into()
+        // Self { transaction_id: outpoint.transaction_id, index: outpoint.index }
+    }
+}
+
+impl From<RpcTransactionOutpoint> for kaspa_consensus_client::TransactionOutpoint {
+    fn from(outpoint: RpcTransactionOutpoint) -> Self {
+        // Self { transaction_id: outpoint.transaction_id, index: outpoint.index }
+        TransactionOutpoint::from(outpoint).into()
+    }
+}
+
+impl Serializer for RpcTransactionOutpoint {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        store!(u8, &1, writer)?;
+        store!(TransactionId, &self.transaction_id, writer)?;
+        store!(TransactionIndexType, &self.index, writer)?;
+
+        Ok(())
+    }
+
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let _version = load!(u8, reader)?;
+        let transaction_id = load!(TransactionId, reader)?;
+        let index = load!(TransactionIndexType, reader)?;
+
+        Ok(Self { transaction_id, index })
+    }
+}
 
 /// Represents a Kaspa transaction input
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcTransactionInput {
     pub previous_outpoint: RpcTransactionOutpoint,
@@ -32,7 +142,7 @@ pub struct RpcTransactionInput {
 impl From<TransactionInput> for RpcTransactionInput {
     fn from(input: TransactionInput) -> Self {
         Self {
-            previous_outpoint: input.previous_outpoint,
+            previous_outpoint: input.previous_outpoint.into(),
             signature_script: input.signature_script,
             sequence: input.sequence,
             sig_op_count: input.sig_op_count,
@@ -47,13 +157,49 @@ impl RpcTransactionInput {
     }
 }
 
+impl Serializer for RpcTransactionInput {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        store!(u8, &1, writer)?;
+        serialize!(RpcTransactionOutpoint, &self.previous_outpoint, writer)?;
+        store!(Vec<u8>, &self.signature_script, writer)?;
+        store!(u64, &self.sequence, writer)?;
+        store!(u8, &self.sig_op_count, writer)?;
+        serialize!(Option<RpcTransactionInputVerboseData>, &self.verbose_data, writer)?;
+
+        Ok(())
+    }
+
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let _version = load!(u8, reader)?;
+        let previous_outpoint = deserialize!(RpcTransactionOutpoint, reader)?;
+        let signature_script = load!(Vec<u8>, reader)?;
+        let sequence = load!(u64, reader)?;
+        let sig_op_count = load!(u8, reader)?;
+        let verbose_data = deserialize!(Option<RpcTransactionInputVerboseData>, reader)?;
+
+        Ok(Self { previous_outpoint, signature_script, sequence, sig_op_count, verbose_data })
+    }
+}
+
 /// Represent Kaspa transaction input verbose data
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcTransactionInputVerboseData {}
 
+impl Serializer for RpcTransactionInputVerboseData {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        store!(u8, &1, writer)?;
+        Ok(())
+    }
+
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let _version = load!(u8, reader)?;
+        Ok(Self {})
+    }
+}
+
 /// Represents a Kaspad transaction output
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcTransactionOutput {
     pub value: u64,
@@ -73,16 +219,54 @@ impl From<TransactionOutput> for RpcTransactionOutput {
     }
 }
 
+impl Serializer for RpcTransactionOutput {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        store!(u8, &1, writer)?;
+        store!(u64, &self.value, writer)?;
+        store!(RpcScriptPublicKey, &self.script_public_key, writer)?;
+        serialize!(Option<RpcTransactionOutputVerboseData>, &self.verbose_data, writer)?;
+
+        Ok(())
+    }
+
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let _version = load!(u8, reader)?;
+        let value = load!(u64, reader)?;
+        let script_public_key = load!(RpcScriptPublicKey, reader)?;
+        let verbose_data = deserialize!(Option<RpcTransactionOutputVerboseData>, reader)?;
+
+        Ok(Self { value, script_public_key, verbose_data })
+    }
+}
+
 /// Represent Kaspa transaction output verbose data
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcTransactionOutputVerboseData {
     pub script_public_key_type: RpcScriptClass,
     pub script_public_key_address: Address,
 }
 
+impl Serializer for RpcTransactionOutputVerboseData {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        store!(u8, &1, writer)?;
+        store!(RpcScriptClass, &self.script_public_key_type, writer)?;
+        store!(Address, &self.script_public_key_address, writer)?;
+
+        Ok(())
+    }
+
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let _version = load!(u8, reader)?;
+        let script_public_key_type = load!(RpcScriptClass, reader)?;
+        let script_public_key_address = load!(Address, reader)?;
+
+        Ok(Self { script_public_key_type, script_public_key_address })
+    }
+}
+
 /// Represents a Kaspa transaction
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcTransaction {
     pub version: u16,
@@ -97,8 +281,40 @@ pub struct RpcTransaction {
     pub verbose_data: Option<RpcTransactionVerboseData>,
 }
 
+impl Serializer for RpcTransaction {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        store!(u16, &1, writer)?;
+        store!(u16, &self.version, writer)?;
+        serialize!(Vec<RpcTransactionInput>, &self.inputs, writer)?;
+        serialize!(Vec<RpcTransactionOutput>, &self.outputs, writer)?;
+        store!(u64, &self.lock_time, writer)?;
+        store!(RpcSubnetworkId, &self.subnetwork_id, writer)?;
+        store!(u64, &self.gas, writer)?;
+        store!(Vec<u8>, &self.payload, writer)?;
+        store!(u64, &self.mass, writer)?;
+        serialize!(Option<RpcTransactionVerboseData>, &self.verbose_data, writer)?;
+
+        Ok(())
+    }
+
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let _struct_version = load!(u16, reader)?;
+        let version = load!(u16, reader)?;
+        let inputs = deserialize!(Vec<RpcTransactionInput>, reader)?;
+        let outputs = deserialize!(Vec<RpcTransactionOutput>, reader)?;
+        let lock_time = load!(u64, reader)?;
+        let subnetwork_id = load!(RpcSubnetworkId, reader)?;
+        let gas = load!(u64, reader)?;
+        let payload = load!(Vec<u8>, reader)?;
+        let mass = load!(u64, reader)?;
+        let verbose_data = deserialize!(Option<RpcTransactionVerboseData>, reader)?;
+
+        Ok(Self { version, inputs, outputs, lock_time, subnetwork_id, gas, payload, mass, verbose_data })
+    }
+}
+
 /// Represent Kaspa transaction verbose data
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcTransactionVerboseData {
     pub transaction_id: RpcTransactionId,
@@ -106,6 +322,30 @@ pub struct RpcTransactionVerboseData {
     pub mass: u64,
     pub block_hash: RpcHash,
     pub block_time: u64,
+}
+
+impl Serializer for RpcTransactionVerboseData {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        store!(u8, &1, writer)?;
+        store!(RpcTransactionId, &self.transaction_id, writer)?;
+        store!(RpcHash, &self.hash, writer)?;
+        store!(u64, &self.mass, writer)?;
+        store!(RpcHash, &self.block_hash, writer)?;
+        store!(u64, &self.block_time, writer)?;
+
+        Ok(())
+    }
+
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let _version = load!(u8, reader)?;
+        let transaction_id = load!(RpcTransactionId, reader)?;
+        let hash = load!(RpcHash, reader)?;
+        let mass = load!(u64, reader)?;
+        let block_hash = load!(RpcHash, reader)?;
+        let block_time = load!(u64, reader)?;
+
+        Ok(Self { transaction_id, hash, mass, block_hash, block_time })
+    }
 }
 
 /// Represents accepted transaction ids

--- a/rpc/core/src/wasm/convert.rs
+++ b/rpc/core/src/wasm/convert.rs
@@ -1,12 +1,11 @@
 use crate::model::*;
 use kaspa_consensus_client::*;
-use kaspa_consensus_core::tx as cctx;
 use std::sync::Arc;
 
 impl From<RpcUtxosByAddressesEntry> for UtxoEntry {
     fn from(entry: RpcUtxosByAddressesEntry) -> UtxoEntry {
         let RpcUtxosByAddressesEntry { address, outpoint, utxo_entry } = entry;
-        let cctx::UtxoEntry { amount, script_public_key, block_daa_score, is_coinbase } = utxo_entry;
+        let RpcUtxoEntry { amount, script_public_key, block_daa_score, is_coinbase } = utxo_entry;
         UtxoEntry { address, outpoint: outpoint.into(), amount, script_public_key, block_daa_score, is_coinbase }
     }
 }

--- a/rpc/service/src/converter/consensus.rs
+++ b/rpc/service/src/converter/consensus.rs
@@ -81,7 +81,7 @@ impl ConsensusConverter {
             vec![]
         };
 
-        Ok(RpcBlock { header: (*block.header).clone(), transactions, verbose_data })
+        Ok(RpcBlock { header: block.header.as_ref().into(), transactions, verbose_data })
     }
 
     pub fn get_mempool_entry(&self, consensus: &ConsensusProxy, transaction: &MutableTransaction) -> RpcMempoolEntry {

--- a/testing/integration/src/common/utils.rs
+++ b/testing/integration/src/common/utils.rs
@@ -16,7 +16,7 @@ use kaspa_consensus_core::{
 };
 use kaspa_core::info;
 use kaspa_grpc_client::GrpcClient;
-use kaspa_rpc_core::{api::rpc::RpcApi, BlockAddedNotification, Notification, VirtualDaaScoreChangedNotification};
+use kaspa_rpc_core::{api::rpc::RpcApi, BlockAddedNotification, Notification, RpcUtxoEntry, VirtualDaaScoreChangedNotification};
 use kaspa_txscript::pay_to_address_script;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 use secp256k1::Keypair;
@@ -170,13 +170,13 @@ pub async fn fetch_spendable_utxos(
     {
         assert!(resp_entry.address.is_some());
         assert_eq!(*resp_entry.address.as_ref().unwrap(), address);
-        utxos.push((resp_entry.outpoint, resp_entry.utxo_entry));
+        utxos.push((TransactionOutpoint::from(resp_entry.outpoint), UtxoEntry::from(resp_entry.utxo_entry)));
     }
     utxos.sort_by(|a, b| b.1.amount.cmp(&a.1.amount));
     utxos
 }
 
-pub fn is_utxo_spendable(entry: &UtxoEntry, virtual_daa_score: u64, coinbase_maturity: u64) -> bool {
+pub fn is_utxo_spendable(entry: &RpcUtxoEntry, virtual_daa_score: u64, coinbase_maturity: u64) -> bool {
     let needed_confirmations = if !entry.is_coinbase { 10 } else { coinbase_maturity };
     entry.block_daa_score + needed_confirmations <= virtual_daa_score
 }


### PR DESCRIPTION
This PR converts various consensus structs that were previously type-aliased in RPC into dedicated RPC structs.

The main purpose of this is to provide custom version-supporting serialization for RPC structs, but RpcHeader is also provisionally decoupled in order to implement various versions of RpcHeader with and without `hash` field (or implement hash as `Option`, I still haven't decided on the best approach).

This PR is for sanity check reasons.  Conversion from type aliases to structs requires a number of `From<>` trait implementations which look to be benign, in some places replacing `clone()` into `into()`.  I don't really see any adverse effects resulting from these changes.  (Serializer trait impls can be ignored).