### PR TITLE
Fix recursive use of an object in WASM32

### DIFF
--- a/consensus/client/src/signing.rs
+++ b/consensus/client/src/signing.rs
@@ -161,11 +161,8 @@ pub fn calc_schnorr_signature_hash(
     // hash_type: SigHashType,
     // reused_values: &mut SigHashReusedValues,
 ) -> Result<Hash> {
-    // let tx = Transaction::try_cast_from(tx.as_ref())?;
-    let tx = Transaction::try_cast_from(tx)?;
-
-    let input = TransactionInput::try_cast_from(input)?;
-    // let input = TransactionInput::try_cast_from(input.as_ref())?;
+    let tx = Transaction::try_owned_from(tx)?;
+    let input = TransactionInput::try_owned_from(input)?;
 
     // let utxo = input.
 

--- a/consensus/client/src/utils.rs
+++ b/consensus/client/src/utils.rs
@@ -13,8 +13,8 @@ use kaspa_wasm_core::types::{BinaryT, HexString};
 /// @category Wallet SDK
 #[wasm_bindgen(js_name = payToAddressScript)]
 pub fn pay_to_address_script(address: AddressT) -> Result<ScriptPublicKey> {
-    let address = Address::try_cast_from(address)?;
-    Ok(standard::pay_to_address_script(address.as_ref()))
+    let address = Address::try_owned_from(address)?;
+    Ok(standard::pay_to_address_script(&address))
 }
 
 /// Takes a script and returns an equivalent pay-to-script-hash script.
@@ -44,10 +44,10 @@ pub fn pay_to_script_hash_signature_script(redeem_script: BinaryT, signature: Bi
 /// @category Wallet SDK
 #[wasm_bindgen(js_name = addressFromScriptPublicKey)]
 pub fn address_from_script_public_key(script_public_key: ScriptPublicKeyT, network: &NetworkTypeT) -> Result<AddressOrUndefinedT> {
-    let script_public_key = ScriptPublicKey::try_cast_from(script_public_key)?;
+    let script_public_key = ScriptPublicKey::try_owned_from(script_public_key)?;
     let network_type = NetworkType::try_from(network)?;
 
-    match standard::extract_script_pub_key_address(script_public_key.as_ref(), network_type.into()) {
+    match standard::extract_script_pub_key_address(&script_public_key, network_type.into()) {
         Ok(address) => Ok(AddressOrUndefinedT::from(JsValue::from(address))),
         Err(_) => Ok(AddressOrUndefinedT::from(JsValue::UNDEFINED)),
     }

--- a/consensus/core/src/network.rs
+++ b/consensus/core/src/network.rs
@@ -115,7 +115,7 @@ impl Display for NetworkType {
 impl TryFrom<&NetworkTypeT> for NetworkType {
     type Error = NetworkTypeError;
     fn try_from(value: &NetworkTypeT) -> Result<Self, Self::Error> {
-        if let Ok(network_id) = NetworkId::try_cast_from(value) {
+        if let Ok(network_id) = NetworkId::try_owned_from(value) {
             Ok(network_id.network_type())
         } else if let Some(network_type) = value.as_string() {
             Self::from_str(&network_type)
@@ -359,7 +359,7 @@ impl<'de> Deserialize<'de> for NetworkId {
 impl NetworkId {
     #[wasm_bindgen(constructor)]
     pub fn ctor(value: &JsValue) -> Result<NetworkId, NetworkIdError> {
-        Ok(NetworkId::try_cast_from(value)?.into_owned())
+        NetworkId::try_owned_from(value)
     }
 
     #[wasm_bindgen(getter, js_name = "id")]

--- a/consensus/pow/src/wasm.rs
+++ b/consensus/pow/src/wasm.rs
@@ -35,8 +35,7 @@ impl PoW {
         // this function replicates crate::State::new() but caches
         // the pre_pow_hash value internally, making it available
         // via the `pre_pow_hash` property getter.
-        let header = Header::try_cast_from(header).map_err(Error::custom)?;
-        let header = header.as_ref();
+        let header = Header::try_owned_from(header).map_err(Error::custom)?;
         let header = header.inner();
 
         // Get required target from header bits.

--- a/rpc/wrpc/wasm/src/resolver.rs
+++ b/rpc/wrpc/wasm/src/resolver.rs
@@ -192,12 +192,12 @@ impl TryFrom<IResolverConfig> for NativeResolver {
     }
 }
 
-impl TryCastFromJs for Resolver {
-    type Error = Error;
-    fn try_cast_from(value: impl AsRef<JsValue>) -> Result<Cast<Self>> {
-        Ok(Self::try_ref_from_js_value_as_cast(value)?)
-    }
-}
+// impl TryCastFromJs for Resolver {
+//     type Error = Error;
+//     fn try_cast_from(value: impl AsRef<JsValue>) -> Result<Cast<Self>> {
+//         Ok(Self::try_ref_from_js_value_as_cast(value)?)
+//     }
+// }
 
 impl TryFrom<&JsValue> for Resolver {
     type Error = Error;

--- a/wallet/core/src/derivation.rs
+++ b/wallet/core/src/derivation.rs
@@ -463,14 +463,8 @@ pub fn create_address_js(
     ecdsa: Option<bool>,
     account_kind: Option<AccountKind>,
 ) -> Result<Address> {
-    let public_key = PublicKey::try_cast_from(key)?;
-    create_address(
-        1,
-        vec![public_key.as_ref().try_into()?],
-        NetworkType::try_from(network)?.into(),
-        ecdsa.unwrap_or(false),
-        account_kind,
-    )
+    let public_key = PublicKey::try_owned_from(key)?;
+    create_address(1, vec![public_key.try_into()?], NetworkType::try_from(network)?.into(), ecdsa.unwrap_or(false), account_kind)
 }
 
 /// @category Wallet SDK

--- a/wallet/core/src/wasm/cryptobox.rs
+++ b/wallet/core/src/wasm/cryptobox.rs
@@ -115,8 +115,8 @@ impl CryptoBox {
     #[wasm_bindgen(constructor)]
     #[allow(non_snake_case)]
     pub fn ctor(secretKey: CryptoBoxPrivateKeyT, peerPublicKey: CryptoBoxPublicKeyT) -> Result<CryptoBox> {
-        let secret_key = CryptoBoxPrivateKey::try_cast_from(secretKey)?;
-        let peer_public_key = CryptoBoxPublicKey::try_cast_from(peerPublicKey)?;
+        let secret_key = CryptoBoxPrivateKey::try_owned_from(secretKey)?;
+        let peer_public_key = CryptoBoxPublicKey::try_owned_from(peerPublicKey)?;
         Ok(Self { inner: Arc::new(NativeCryptoBox::new(&secret_key, &peer_public_key)) })
     }
 

--- a/wallet/core/src/wasm/signer.rs
+++ b/wallet/core/src/wasm/signer.rs
@@ -38,8 +38,8 @@ pub fn js_sign_transaction(tx: Transaction, signer: PrivateKeyArrayT, verify_sig
     if signer.is_array() {
         let mut private_keys: Vec<[u8; 32]> = vec![];
         for key in Array::from(&signer).iter() {
-            let key = PrivateKey::try_cast_from(key).map_err(|_| Error::Custom("Unable to cast PrivateKey".to_string()))?;
-            private_keys.push(key.as_ref().secret_bytes());
+            let key = PrivateKey::try_owned_from(key).map_err(|_| Error::Custom("Unable to cast PrivateKey".to_string()))?;
+            private_keys.push(key.secret_bytes());
         }
 
         let tx = sign_transaction(tx, &private_keys, verify_sig).map_err(|err| Error::Custom(format!("Unable to sign: {err:?}")))?;

--- a/wallet/core/src/wasm/tx/mass.rs
+++ b/wallet/core/src/wasm/tx/mass.rs
@@ -16,12 +16,12 @@ use workflow_wasm::convert::*;
 ///
 #[wasm_bindgen(js_name = calculateTransactionMass)]
 pub fn calculate_transaction_mass(network_id: NetworkIdT, tx: &TransactionT) -> Result<Option<u64>> {
-    let tx = Transaction::try_cast_from(tx)?;
+    let tx = Transaction::try_owned_from(tx)?;
     let network_id = NetworkId::try_owned_from(network_id)?;
     let consensus_params = Params::from(network_id);
     let network_params = NetworkParams::from(network_id);
     let mc = mass::MassCalculator::new(&consensus_params, network_params);
-    mc.calc_tx_overall_mass(tx.as_ref())
+    mc.calc_tx_overall_mass(&tx)
 }
 
 /// `calculateTransactionFee()` returns minimum fees needed for the transaction to be
@@ -33,11 +33,11 @@ pub fn calculate_transaction_mass(network_id: NetworkIdT, tx: &TransactionT) -> 
 ///
 #[wasm_bindgen(js_name = calculateTransactionFee)]
 pub fn calculate_transaction_fee(network_id: NetworkIdT, tx: &TransactionT) -> Result<Option<u64>> {
-    let tx = Transaction::try_cast_from(tx)?;
+    let tx = Transaction::try_owned_from(tx)?;
     let network_id = NetworkId::try_owned_from(network_id)?;
     let consensus_params = Params::from(network_id);
     let network_params = NetworkParams::from(network_id);
     let mc = mass::MassCalculator::new(&consensus_params, network_params);
-    let fee = mc.calc_tx_overall_mass(tx.as_ref())?.map(|mass| mc.calc_fee_for_mass(mass));
+    let fee = mc.calc_tx_overall_mass(&tx)?.map(|mass| mc.calc_fee_for_mass(mass));
     Ok(fee)
 }

--- a/wallet/core/src/wasm/utxo/processor.rs
+++ b/wallet/core/src/wasm/utxo/processor.rs
@@ -149,8 +149,8 @@ impl UtxoProcessor {
 
     #[wasm_bindgen(js_name = "setNetworkId")]
     pub fn set_network_id(&self, network_id: &NetworkIdT) -> Result<()> {
-        let network_id = NetworkId::try_cast_from(network_id)?;
-        self.inner.processor.set_network_id(network_id.as_ref());
+        let network_id = NetworkId::try_owned_from(network_id)?;
+        self.inner.processor.set_network_id(&network_id);
         Ok(())
     }
 
@@ -172,7 +172,7 @@ impl UtxoProcessor {
     ///
     #[wasm_bindgen(js_name = "setCoinbaseTransactionMaturityDAA")]
     pub fn set_coinbase_transaction_maturity_period_daa_js(network_id: NetworkIdT, value: u64) -> Result<()> {
-        let network_id = NetworkId::try_cast_from(network_id)?.into_owned();
+        let network_id = NetworkId::try_owned_from(network_id)?;
         crate::utxo::set_coinbase_transaction_maturity_period_daa(&network_id, value);
         Ok(())
     }

--- a/wallet/keys/src/privkeygen.rs
+++ b/wallet/keys/src/privkeygen.rs
@@ -21,8 +21,8 @@ pub struct PrivateKeyGenerator {
 impl PrivateKeyGenerator {
     #[wasm_bindgen(constructor)]
     pub fn new(xprv: &XPrvT, is_multisig: bool, account_index: u64, cosigner_index: Option<u32>) -> Result<PrivateKeyGenerator> {
-        let xprv = XPrv::try_cast_from(xprv)?;
-        let xprv = xprv.as_ref().inner();
+        let xprv = XPrv::try_owned_from(xprv)?;
+        let xprv = xprv.inner();
         let receive = xprv.clone().derive_path(&WalletDerivationManager::build_derivate_path(
             is_multisig,
             account_index,

--- a/wallet/keys/src/pubkeygen.rs
+++ b/wallet/keys/src/pubkeygen.rs
@@ -22,8 +22,8 @@ pub struct PublicKeyGenerator {
 impl PublicKeyGenerator {
     #[wasm_bindgen(js_name=fromXPub)]
     pub fn from_xpub(kpub: XPubT, cosigner_index: Option<u32>) -> Result<PublicKeyGenerator> {
-        let kpub = XPub::try_cast_from(kpub)?;
-        let xpub = kpub.as_ref().inner();
+        let kpub = XPub::try_owned_from(kpub)?;
+        let xpub = kpub.inner();
         let hd_wallet = WalletDerivationManager::from_extended_public_key(xpub.clone(), cosigner_index)?;
         Ok(Self { hd_wallet })
     }

--- a/wallet/keys/src/xprv.rs
+++ b/wallet/keys/src/xprv.rs
@@ -51,8 +51,8 @@ impl XPrv {
 
     #[wasm_bindgen(js_name=derivePath)]
     pub fn derive_path(&self, path: &JsValue) -> Result<XPrv> {
-        let path = DerivationPath::try_cast_from(path)?;
-        let inner = self.inner.clone().derive_path(path.as_ref().into())?;
+        let path = DerivationPath::try_owned_from(path)?;
+        let inner = self.inner.clone().derive_path((&path).into())?;
         Ok(Self { inner })
     }
 

--- a/wallet/keys/src/xpub.rs
+++ b/wallet/keys/src/xpub.rs
@@ -43,8 +43,8 @@ impl XPub {
 
     #[wasm_bindgen(js_name=derivePath)]
     pub fn derive_path(&self, path: &JsValue) -> Result<XPub> {
-        let path = DerivationPath::try_cast_from(path)?;
-        let inner = self.inner.clone().derive_path(path.as_ref().into())?;
+        let path = DerivationPath::try_owned_from(path)?;
+        let inner = self.inner.clone().derive_path((&path).into())?;
         Ok(Self { inner })
     }
 


### PR DESCRIPTION
This addresses https://github.com/kaspanet/rusty-kaspa/issues/516

It appears that holding a `Cast` to `JsValue` can result in "out of order" drop that drops `JsValue` before the cast, causing multiple borrow access to the internal data of the given `JsValue` (`Cast` holds a `Ref` while `JsValue::drop()` requires `borrow_mut()`, causing a borrow panic.

I have converted `try_cast_from()` calls to `try_owned_from()` which is equivalent to `try_cast_from()?.into_owned()` making the `Cast` "transient" in nature (thus dropping the `Ref` immediately).  This appears to have solved the issue.

Not yet sure what the correct approach would be to prevent this.  Technically, this should be handled via lifetimes making `Cast` carry the lifetime of the supplied `&JsValue`, but not quite sure this is possible, need to experiment to see if the lifetime can be introduced and propagated.  An alternative approach would be to have a `Cast` clone and then own a source `JsValue` so that the `JsValue` used to access the ABI cell is isolated and its drop is synchronized with the `Cast` itself.