### PR TITLE
WASM SDK: rpc.submitTransaction produces "missing field transaction" error

### DIFF
--- a/consensus/client/src/transaction.rs
+++ b/consensus/client/src/transaction.rs
@@ -214,12 +214,12 @@ impl Transaction {
         self.inner().version = v;
     }
 
-    #[wasm_bindgen(getter, js_name = lock_time)]
+    #[wasm_bindgen(getter, js_name = lockTime)]
     pub fn get_lock_time(&self) -> u64 {
         self.inner().lock_time
     }
 
-    #[wasm_bindgen(setter, js_name = lock_time)]
+    #[wasm_bindgen(setter, js_name = lockTime)]
     pub fn set_lock_time(&self, v: u64) {
         self.inner().lock_time = v;
     }

--- a/rpc/core/src/wasm/message.rs
+++ b/rpc/core/src/wasm/message.rs
@@ -1414,7 +1414,11 @@ try_from! ( args: ISubmitTransactionRequest, SubmitTransactionRequest, {
             allow_orphan,
         }
     } else {
-        from_value(transaction)?
+        let tx = Transaction::try_cast_from(&transaction)?;
+        SubmitTransactionRequest {
+          transaction : tx.as_ref().into(),
+          allow_orphan,
+        }
     };
     Ok(request)
 });


### PR DESCRIPTION
Having the following code from example https://github.com/kaspanet/rusty-kaspa/blob/master/wasm/examples/nodejs/javascript/transactions/single-transaction-demo.js :

This code produces "missing field `transaction`" error as a part of `let result = await rpc.submitTransaction({transaction});` call.

It turned out the issue is with this code, `else` branch:

```
    let request = if let Ok(transaction) = Transaction::try_owned_from(&transaction) {
        SubmitTransactionRequest {
            transaction : transaction.into(),
            allow_orphan,
        }
    } else {
      from_value(transaction)? 
    };
```
means it return a transaction object instead of `SubmitTransactionRequest` object.
Once this is fixed, there were some more incompatibility errors, that are now addressed with this PR