### PR TITLE
PyBinary interface type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2576,6 +2576,7 @@ dependencies = [
  "kaspa-consensus-core",
  "kaspa-hashes",
  "kaspa-math",
+ "kaspa-python-core",
  "kaspa-txscript",
  "kaspa-utils",
  "kaspa-wasm-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3139,6 +3139,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kaspa-python-core"
+version = "0.15.2"
+dependencies = [
+ "cfg-if 1.0.0",
+ "faster-hex",
+ "pyo3",
+]
+
+[[package]]
 name = "kaspa-python-macros"
 version = "0.15.2"
 dependencies = [
@@ -3311,6 +3320,7 @@ dependencies = [
  "kaspa-addresses",
  "kaspa-consensus-core",
  "kaspa-hashes",
+ "kaspa-python-core",
  "kaspa-txscript-errors",
  "kaspa-utils",
  "kaspa-wasm-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2612,6 +2612,7 @@ dependencies = [
  "kaspa-math",
  "kaspa-merkle",
  "kaspa-muhash",
+ "kaspa-python-core",
  "kaspa-txscript-errors",
  "kaspa-utils",
  "pyo3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3486,6 +3486,7 @@ dependencies = [
  "kaspa-hashes",
  "kaspa-metrics-core",
  "kaspa-notify",
+ "kaspa-python-core",
  "kaspa-python-macros",
  "kaspa-rpc-core",
  "kaspa-txscript",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ members = [
     "utils/alloc",
     "python",
     "python/macros",
+    "python/core",
 ]
 
 [workspace.package]
@@ -116,6 +117,7 @@ kaspa-p2p-lib = { version = "0.15.2", path = "protocol/p2p" }
 kaspa-perf-monitor = { version = "0.15.2", path = "metrics/perf_monitor" }
 kaspa-pow = { version = "0.15.2", path = "consensus/pow" }
 kaspa-python = { version = "0.15.2", path = "python" }
+kaspa-python-core = { version = "0.15.2", path = "python/core" }
 kaspa-python-macros = { version = "0.15.2", path = "python/macros" }
 kaspa-rpc-core = { version = "0.15.2", path = "rpc/core" }
 kaspa-rpc-macros = { version = "0.15.2", path = "rpc/macros" }

--- a/consensus/client/Cargo.toml
+++ b/consensus/client/Cargo.toml
@@ -14,6 +14,7 @@ wasm32-types = []
 py-sdk = [
     "pyo3",
     "kaspa-hashes/py-sdk",
+    "kaspa-python-core/py-sdk",
     "serde-pyobject",
 ]
 
@@ -22,6 +23,7 @@ kaspa-addresses.workspace = true
 kaspa-consensus-core.workspace = true
 kaspa-hashes.workspace = true
 kaspa-math.workspace = true
+kaspa-python-core = { workspace = true, optional = true }
 kaspa-txscript.workspace = true
 kaspa-utils.workspace = true
 kaspa-wasm-core.workspace = true

--- a/consensus/client/src/imports.rs
+++ b/consensus/client/src/imports.rs
@@ -10,6 +10,7 @@ pub use workflow_wasm::prelude::*;
 cfg_if::cfg_if! {
     if #[cfg(feature = "py-sdk")] {
         pub use kaspa_addresses::Address;
+        pub use kaspa_python_core::types::PyBinary;
         pub use kaspa_utils::hex::FromHex;
         pub use pyo3::{
             exceptions::PyException,

--- a/consensus/client/src/input.rs
+++ b/consensus/client/src/input.rs
@@ -176,13 +176,12 @@ impl TransactionInput {
     #[new]
     pub fn constructor_py(
         previous_outpoint: TransactionOutpoint,
-        signature_script: String,
+        signature_script: PyBinary,
         sequence: u64,
         sig_op_count: u8,
         utxo: Option<UtxoEntryReference>,
     ) -> PyResult<Self> {
-        let signature_script = Vec::from_hex(&signature_script).map_err(|err| PyException::new_err(format!("{}", err)))?;
-        Ok(Self::new(previous_outpoint, Some(signature_script), sequence, sig_op_count, utxo))
+        Ok(Self::new(previous_outpoint, Some(signature_script.into()), sequence, sig_op_count, utxo))
     }
 
     #[getter]
@@ -207,9 +206,8 @@ impl TransactionInput {
 
     #[setter]
     #[pyo3(name = "signature_script")]
-    pub fn set_signature_script_as_hex_py(&mut self, signature_script: String) -> PyResult<()> {
-        let signature_script = Vec::from_hex(&signature_script).map_err(|err| PyException::new_err(format!("{}", err)))?;
-        self.set_signature_script(signature_script);
+    pub fn set_signature_script_as_hex_py(&mut self, signature_script: PyBinary) -> PyResult<()> {
+        self.set_signature_script(signature_script.into());
         Ok(())
     }
 

--- a/consensus/client/src/transaction.rs
+++ b/consensus/client/src/transaction.rs
@@ -301,7 +301,7 @@ impl Transaction {
         lock_time: u64,
         subnetwork_id: String,
         gas: u64,
-        payload: Vec<u8>,
+        payload: PyBinary,
         mass: u64,
     ) -> PyResult<Self> {
         let subnetwork_id = Vec::from_hex(&subnetwork_id)
@@ -310,7 +310,7 @@ impl Transaction {
             .try_into()
             .map_err(|err| PyException::new_err(format!("subnetwork_id conversion error: {}", err)))?;
 
-        Ok(Transaction::new(None, version, inputs, outputs, lock_time, subnetwork_id, gas, payload, mass)
+        Ok(Transaction::new(None, version, inputs, outputs, lock_time, subnetwork_id, gas, payload.into(), mass)
             .map_err(|err| PyException::new_err(format!("{}", err)))?)
     }
 
@@ -417,9 +417,8 @@ impl Transaction {
 
     #[setter]
     #[pyo3(name = "payload")]
-    pub fn set_payload_from_py_value(&mut self, v: String) {
-        let payload = Vec::from_hex(&v).unwrap_or_else(|err| panic!("Hex decode error {}", err));
-        self.inner.lock().unwrap().payload = payload;
+    pub fn set_payload_from_py_value(&mut self, v: PyBinary) {
+        self.inner.lock().unwrap().payload = v.into();
     }
 }
 

--- a/consensus/core/Cargo.toml
+++ b/consensus/core/Cargo.toml
@@ -13,7 +13,10 @@ repository.workspace = true
 devnet-prealloc = []
 wasm32-sdk = []
 default = []
-py-sdk = ["pyo3"]
+py-sdk = [
+    "pyo3",
+    "kaspa-python-core/py-sdk",
+]
 
 [dependencies]
 async-trait.workspace = true
@@ -30,6 +33,7 @@ kaspa-hashes.workspace = true
 kaspa-math.workspace = true
 kaspa-merkle.workspace = true
 kaspa-muhash.workspace = true
+kaspa-python-core = { workspace = true, optional = true }
 kaspa-txscript-errors.workspace = true
 kaspa-utils.workspace = true
 pyo3 = { workspace = true, optional = true }

--- a/consensus/core/src/tx/script_public_key.rs
+++ b/consensus/core/src/tx/script_public_key.rs
@@ -357,9 +357,8 @@ impl ScriptPublicKey {
 #[pymethods]
 impl ScriptPublicKey {
     #[new]
-    pub fn constructor_py(version: u16, script: String) -> PyResult<ScriptPublicKey> {
-        let script = Vec::from_hex(&script).map_err(|err| pyo3::exceptions::PyException::new_err(format!("{}", err)))?;
-        Ok(ScriptPublicKey::new(version, script.into()))
+    pub fn constructor_py(version: u16, script: kaspa_python_core::types::PyBinary) -> PyResult<ScriptPublicKey> {
+        Ok(ScriptPublicKey::new(version, script.data.into()))
     }
 
     #[getter]

--- a/crypto/txscript/Cargo.toml
+++ b/crypto/txscript/Cargo.toml
@@ -10,7 +10,10 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-py-sdk = ["pyo3"]
+py-sdk = [
+    "pyo3",
+    "kaspa-python-core/py-sdk",
+]
 wasm32-core = []
 wasm32-sdk = []
 
@@ -25,6 +28,7 @@ itertools.workspace = true
 kaspa-addresses.workspace = true
 kaspa-consensus-core.workspace = true
 kaspa-hashes.workspace = true
+kaspa-python-core = { workspace = true, optional = true }
 kaspa-txscript-errors.workspace = true
 kaspa-utils.workspace = true
 kaspa-wasm-core.workspace = true

--- a/crypto/txscript/src/python/builder.rs
+++ b/crypto/txscript/src/python/builder.rs
@@ -1,8 +1,9 @@
 use crate::result::Result;
 use crate::wasm::opcodes::Opcodes;
 use crate::{script_builder as native, standard};
-use faster_hex::hex_decode;
+use kaspa_consensus_core::sign;
 use kaspa_consensus_core::tx::ScriptPublicKey;
+use kaspa_python_core::types::PyBinary;
 use kaspa_utils::hex::ToHex;
 use pyo3::prelude::*;
 use std::sync::{Arc, Mutex, MutexGuard};
@@ -34,10 +35,9 @@ impl ScriptBuilder {
     }
 
     #[staticmethod]
-    pub fn from_script(script: Bound<PyAny>) -> PyResult<ScriptBuilder> {
+    pub fn from_script(script: PyBinary) -> PyResult<ScriptBuilder> {
         let builder = ScriptBuilder::default();
-        let script = PyBinary::try_from(script)?;
-        builder.inner().extend(&script.data);
+        builder.inner().extend(script.as_ref());
 
         Ok(builder)
     }
@@ -57,11 +57,9 @@ impl ScriptBuilder {
         Ok(self.clone())
     }
 
-    pub fn add_data(&self, data: Bound<PyAny>) -> PyResult<ScriptBuilder> {
-        let data = PyBinary::try_from(data)?;
-
+    pub fn add_data(&self, data: PyBinary) -> PyResult<ScriptBuilder> {
         let mut inner = self.inner();
-        inner.add_data(&data.data).map_err(|err| pyo3::exceptions::PyException::new_err(format!("{}", err)))?;
+        inner.add_data(data.as_ref()).map_err(|err| pyo3::exceptions::PyException::new_err(format!("{}", err)))?;
 
         Ok(self.clone())
     }
@@ -88,9 +86,8 @@ impl ScriptBuilder {
     }
 
     #[staticmethod]
-    pub fn canonical_data_size(data: Bound<PyAny>) -> PyResult<u32> {
-        let data = PyBinary::try_from(data)?;
-        let size = native::ScriptBuilder::canonical_data_size(&data.data.as_slice()) as u32;
+    pub fn canonical_data_size(data: PyBinary) -> PyResult<u32> {
+        let size = native::ScriptBuilder::canonical_data_size(data.as_ref()) as u32;
 
         Ok(size)
     }
@@ -116,14 +113,14 @@ impl ScriptBuilder {
     }
 
     #[pyo3(name = "encode_pay_to_script_hash_signature_script")]
-    pub fn pay_to_script_hash_signature_script(&self, signature: String) -> Result<String> {
+    pub fn pay_to_script_hash_signature_script(&self, signature: PyBinary) -> Result<String> {
         // PY-TODO use PyBinary
-        let mut signature_bytes = vec![0u8; signature.len() / 2];
-        faster_hex::hex_decode(signature.as_bytes(), &mut signature_bytes).unwrap();
+        // let mut signature_bytes = vec![0u8; signature.len() / 2];
+        // faster_hex::hex_decode(signature.as_bytes(), &mut signature_bytes).unwrap();
 
         let inner = self.inner();
         let script = inner.script();
-        let generated_script = standard::pay_to_script_hash_signature_script(script.into(), signature_bytes)?;
+        let generated_script = standard::pay_to_script_hash_signature_script(script.into(), signature.into())?;
 
         Ok(generated_script.to_hex().into())
     }
@@ -137,6 +134,7 @@ impl ScriptBuilder {
     // }
 }
 
+// PY-TODO change to PyOpcode struct and handle similar to PyBinary
 fn extract_ops(input: Bound<PyAny>) -> PyResult<Vec<u8>> {
     if let Ok(opcode) = extract_op(&input) {
         // Single u8 or Opcodes variant
@@ -156,32 +154,5 @@ fn extract_op(item: &Bound<PyAny>) -> PyResult<u8> {
         Ok(op.value())
     } else {
         Err(pyo3::exceptions::PyTypeError::new_err("Expected Opcodes variant or u8"))
-    }
-}
-
-struct PyBinary {
-    pub data: Vec<u8>,
-}
-
-impl TryFrom<Bound<'_, PyAny>> for PyBinary {
-    type Error = PyErr;
-    fn try_from(value: Bound<PyAny>) -> Result<Self, Self::Error> {
-        if let Ok(str) = value.extract::<String>() {
-            // Python `str` (of valid hex)
-            let mut data = vec![0u8; str.len() / 2];
-            match hex_decode(str.as_bytes(), &mut data) {
-                Ok(()) => Ok(PyBinary { data }), // Hex string
-                Err(_) => Err(pyo3::exceptions::PyValueError::new_err("Invalid hex string")),
-            }
-        } else if let Ok(py_bytes) = value.downcast::<pyo3::types::PyBytes>() {
-            // Python `bytes` type
-            Ok(PyBinary { data: py_bytes.as_bytes().to_vec() })
-        } else if let Ok(op_list) = value.downcast::<pyo3::types::PyList>() {
-            // Python `[int]` (list of bytes)
-            let data = op_list.iter().map(|item| item.extract::<u8>().unwrap()).collect();
-            Ok(PyBinary { data })
-        } else {
-            Err(pyo3::exceptions::PyTypeError::new_err("Expected `str` (of valid hex), `bytes`, `int` (u8), or `[int]` (u8)"))
-        }
     }
 }

--- a/crypto/txscript/src/python/builder.rs
+++ b/crypto/txscript/src/python/builder.rs
@@ -1,7 +1,6 @@
 use crate::result::Result;
 use crate::wasm::opcodes::Opcodes;
 use crate::{script_builder as native, standard};
-use kaspa_consensus_core::sign;
 use kaspa_consensus_core::tx::ScriptPublicKey;
 use kaspa_python_core::types::PyBinary;
 use kaspa_utils::hex::ToHex;

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -34,3 +34,6 @@ py-sdk = [
     "kaspa-wallet-core/py-sdk",
     "kaspa-wrpc-python/py-sdk",
 ]
+
+[lints]
+workspace = true

--- a/python/core/Cargo.toml
+++ b/python/core/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "kaspa-python-core"
+description = "Kaspa core Python types"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+include.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[features]
+py-sdk = []
+
+[dependencies]
+cfg-if.workspace = true
+pyo3.workspace = true
+faster-hex.workspace = true
+
+[lints]
+workspace = true

--- a/python/core/src/lib.rs
+++ b/python/core/src/lib.rs
@@ -1,0 +1,5 @@
+cfg_if::cfg_if! {
+    if #[cfg(feature = "py-sdk")] {
+        pub mod types;
+    }
+}

--- a/python/core/src/types.rs
+++ b/python/core/src/types.rs
@@ -1,0 +1,64 @@
+use pyo3::exceptions::PyException;
+use pyo3::prelude::*;
+use pyo3::types::{PyBytes, PyList};
+
+pub struct PyBinary {
+    pub data: Vec<u8>,
+}
+
+impl<'a> FromPyObject<'a> for PyBinary {
+    fn extract(value: &'a PyAny) -> PyResult<Self> {
+        if let Ok(str) = value.extract::<String>() {
+            // Python `str` (of valid hex)
+            let mut data = vec![0u8; str.len() / 2];
+            match faster_hex::hex_decode(str.as_bytes(), &mut data) {
+                Ok(()) => Ok(PyBinary { data }), // Hex string
+                Err(_) => Err(PyException::new_err("Invalid hex string")),
+            }
+        } else if let Ok(py_bytes) = value.downcast::<PyBytes>() {
+            // Python `bytes` type
+            Ok(PyBinary { data: py_bytes.as_bytes().to_vec() })
+        } else if let Ok(op_list) = value.downcast::<PyList>() {
+            // Python `[int]` (list of bytes)
+            let data = op_list.iter().map(|item| item.extract::<u8>()).collect::<PyResult<Vec<u8>>>()?;
+            Ok(PyBinary { data })
+        } else {
+            Err(PyException::new_err("Expected `str` (of valid hex), `bytes`, or `[int]`"))
+        }
+    }
+}
+
+impl TryFrom<Bound<'_, PyAny>> for PyBinary {
+    type Error = PyErr;
+    fn try_from(value: Bound<PyAny>) -> Result<Self, Self::Error> {
+        if let Ok(str) = value.extract::<String>() {
+            // Python `str` (of valid hex)
+            let mut data = vec![0u8; str.len() / 2];
+            match faster_hex::hex_decode(str.as_bytes(), &mut data) {
+                Ok(()) => Ok(PyBinary { data }), // Hex string
+                Err(_) => Err(PyException::new_err("Invalid hex string")),
+            }
+        } else if let Ok(py_bytes) = value.downcast::<PyBytes>() {
+            // Python `bytes` type
+            Ok(PyBinary { data: py_bytes.as_bytes().to_vec() })
+        } else if let Ok(op_list) = value.downcast::<PyList>() {
+            // Python `[int]` (list of bytes)
+            let data = op_list.iter().map(|item| item.extract::<u8>().unwrap()).collect();
+            Ok(PyBinary { data })
+        } else {
+            Err(PyException::new_err("Expected `str` (of valid hex), `bytes`, or `[int]`"))
+        }
+    }
+}
+
+impl Into<Vec<u8>> for PyBinary {
+    fn into(self) -> Vec<u8> {
+        self.data
+    }
+}
+
+impl AsRef<[u8]> for PyBinary {
+    fn as_ref(&self) -> &[u8] {
+        self.data.as_slice()
+    }
+}

--- a/python/examples/addresses.py
+++ b/python/examples/addresses.py
@@ -33,8 +33,8 @@ def demo_generate_address_from_private_key_hex_string():
 def demo_generate_random():
     keypair = Keypair.random()
     print("\nRandom Generation")
-    print(keypair.private_key())
-    print(keypair.public_key())
+    print(keypair.private_key)
+    print(keypair.public_key)
     print(keypair.to_address("kaspa").to_string())
 
 if __name__ == "__main__":

--- a/python/examples/transactions/krc20_deploy.py
+++ b/python/examples/transactions/krc20_deploy.py
@@ -28,7 +28,7 @@ async def main():
     data = {
         'p': 'krc-20',
         'op': 'deploy',
-        'tick': 'TPYSDK',
+        'tick': 'PYSDK',
         'max': '112121115100107',
         'lim': '1000',
     }

--- a/python/examples/transactions/krc20_deploy.py
+++ b/python/examples/transactions/krc20_deploy.py
@@ -28,7 +28,7 @@ async def main():
     data = {
         'p': 'krc-20',
         'op': 'deploy',
-        'tick': 'PYSDK',
+        'tick': 'TPYSDK',
         'max': '112121115100107',
         'lim': '1000',
     }

--- a/python/examples/transactions/transaction_simple.py
+++ b/python/examples/transactions/transaction_simple.py
@@ -28,6 +28,7 @@ async def main():
     fee_rates = await client.get_fee_estimate()
     fee = int(fee_rates["estimate"]["priorityBucket"]["feerate"])
 
+    fee = max(fee, 2000)
     output_amount = int(total - fee)
 
     change_address = address

--- a/rpc/wrpc/python/Cargo.toml
+++ b/rpc/wrpc/python/Cargo.toml
@@ -37,3 +37,6 @@ thiserror.workspace = true
 workflow-core.workspace = true
 workflow-log.workspace = true
 workflow-rpc.workspace = true
+
+[lints]
+workspace = true

--- a/wallet/core/Cargo.toml
+++ b/wallet/core/Cargo.toml
@@ -28,6 +28,7 @@ wasm32-sdk = [
 default = ["wasm32-sdk"]
 py-sdk = [
     "kaspa-consensus-core/py-sdk",
+    "kaspa-python-core/py-sdk",
     "kaspa-python-macros",
     "kaspa-wallet-keys/py-sdk",
     "kaspa-wrpc-python/py-sdk",
@@ -74,6 +75,7 @@ kaspa-core.workspace = true
 kaspa-hashes.workspace = true
 kaspa-metrics-core.workspace = true
 kaspa-notify.workspace = true
+kaspa-python-core = { workspace = true, optional = true }
 kaspa-python-macros = { workspace = true, optional = true }
 kaspa-rpc-core.workspace = true
 kaspa-txscript-errors.workspace = true

--- a/wallet/core/src/imports.rs
+++ b/wallet/core/src/imports.rs
@@ -68,6 +68,7 @@ cfg_if! {
 
 cfg_if! {
     if #[cfg(feature = "py-sdk")] {
+        pub use kaspa_python_core::types::PyBinary;
         pub use pyo3::{
             exceptions::PyException,
             prelude::*,

--- a/wallet/core/src/python/tx/generator/generator.rs
+++ b/wallet/core/src/python/tx/generator/generator.rs
@@ -131,7 +131,7 @@ impl GeneratorSettings {
     ) -> GeneratorSettings {
         let network_id = NetworkId::from_str(&network_id).unwrap();
 
-        // PY-TODO 
+        // PY-TODO
         // let final_transaction_destination: PaymentDestination =
         //     if outputs.is_empty() { PaymentDestination::Change } else { PaymentOutputs::try_from(outputs).unwrap().into() };
         let final_transaction_destination: PaymentDestination = PaymentOutputs::try_from(outputs).unwrap().into();

--- a/wallet/core/src/python/tx/generator/generator.rs
+++ b/wallet/core/src/python/tx/generator/generator.rs
@@ -16,7 +16,7 @@ impl Generator {
         entries: Vec<&PyDict>,
         outputs: Vec<&PyDict>,
         change_address: Address,
-        payload: Option<String>, // TODO Hex string for now, use PyBinary
+        payload: Option<PyBinary>,
         priority_fee: Option<u64>,
         priority_entries: Option<Vec<&PyDict>>,
         sig_op_count: Option<u8>,
@@ -30,7 +30,7 @@ impl Generator {
             priority_entries,
             sig_op_count,
             minimum_signatures,
-            payload,
+            payload.map(Into::into),
             network_id,
         );
 
@@ -101,7 +101,6 @@ impl Generator {
 enum GeneratorSource {
     UtxoEntries(Vec<UtxoEntryReference>),
     UtxoContext(UtxoContext),
-    // #[cfg(any(feature = "wasm32-sdk"), not(target_arch = "wasm32"))]
     // Account(Account),
 }
 
@@ -127,11 +126,12 @@ impl GeneratorSettings {
         priority_entries: Option<Vec<&PyDict>>,
         sig_op_count: Option<u8>,
         minimum_signatures: Option<u16>,
-        payload: Option<String>, // TODO Hex string for now, use PyBinary
-        network_id: String,      // TODO this is wrong
+        payload: Option<Vec<u8>>,
+        network_id: String,
     ) -> GeneratorSettings {
         let network_id = NetworkId::from_str(&network_id).unwrap();
 
+        // PY-TODO 
         // let final_transaction_destination: PaymentDestination =
         //     if outputs.is_empty() { PaymentDestination::Change } else { PaymentOutputs::try_from(outputs).unwrap().into() };
         let final_transaction_destination: PaymentDestination = PaymentOutputs::try_from(outputs).unwrap().into();
@@ -141,7 +141,7 @@ impl GeneratorSettings {
             None => Fees::None,
         };
 
-        // TODO support GeneratorSource::UtxoContext and clean up below
+        // PY-TODO support GeneratorSource::UtxoContext and clean up below
         let generator_source =
             GeneratorSource::UtxoEntries(entries.iter().map(|entry| UtxoEntryReference::try_from(*entry).unwrap()).collect());
 
@@ -154,8 +154,6 @@ impl GeneratorSettings {
         let sig_op_count = sig_op_count.unwrap_or(1);
 
         let minimum_signatures = minimum_signatures.unwrap_or(1);
-
-        let payload = payload.map(|s| s.into_bytes());
 
         GeneratorSettings {
             network_id: Some(network_id),

--- a/wallet/core/src/python/tx/generator/pending.rs
+++ b/wallet/core/src/python/tx/generator/pending.rs
@@ -86,11 +86,8 @@ impl PendingTransaction {
         Ok(signature.to_hex())
     }
 
-    fn fill_input(&self, input_index: u8, signature_script: String) -> Result<()> {
-        // TODO use PyBinary for signature_script
-        let mut bytes = vec![0u8; signature_script.len() / 2];
-        faster_hex::hex_decode(signature_script.as_bytes(), &mut bytes).unwrap();
-        self.inner.fill_input(input_index.into(), bytes)?;
+    fn fill_input(&self, input_index: u8, signature_script: PyBinary) -> Result<()> {
+        self.inner.fill_input(input_index.into(), signature_script.into())?;
 
         Ok(())
     }

--- a/wallet/core/src/python/tx/utils.rs
+++ b/wallet/core/src/python/tx/utils.rs
@@ -53,7 +53,7 @@ pub fn create_transactions_py<'a>(
     entries: Vec<&PyDict>,
     outputs: Vec<&PyDict>,
     change_address: Address,
-    payload: Option<String>, // TODO Hex string for now, use PyBinary
+    payload: Option<PyBinary>,
     priority_fee: Option<u64>,
     priority_entries: Option<Vec<&PyDict>>,
     sig_op_count: Option<u8>,
@@ -64,7 +64,7 @@ pub fn create_transactions_py<'a>(
         entries,
         outputs,
         change_address,
-        payload,
+        payload.map(Into::into),
         priority_fee,
         priority_entries,
         sig_op_count,

--- a/wallet/core/src/python/tx/utils.rs
+++ b/wallet/core/src/python/tx/utils.rs
@@ -10,7 +10,7 @@ pub fn create_transaction_py(
     utxo_entry_source: Vec<&PyDict>,
     outputs: Vec<&PyDict>,
     priority_fee: u64,
-    payload: Option<Vec<u8>>, // PY-TODO can this be string?
+    payload: Option<PyBinary>,
     sig_op_count: Option<u8>,
 ) -> PyResult<Transaction> {
     let utxo_entries: Vec<UtxoEntryReference> =
@@ -18,7 +18,7 @@ pub fn create_transaction_py(
 
     let outputs: Vec<PaymentOutput> = outputs.iter().map(|utxo| PaymentOutput::try_from(*utxo)).collect::<Result<Vec<_>, _>>()?;
 
-    let payload = payload.unwrap_or_default();
+    let payload: Vec<u8> = payload.map(Into::into).unwrap_or_default();
     let sig_op_count = sig_op_count.unwrap_or(1);
 
     let mut total_input_amount = 0;


### PR DESCRIPTION
Added crate `kaspa-python-core` (similar to `kaspa-wasm-core`) to store certain Python specific interface types.

New Rust struct `PyBinary` to help provide a standard/flexible interface to Python for binary data. `PyBinary` itself is not exposed to Python as a Python class. Rather, it is used as a parameter type in functions exposed to Python. Specifically for parameters that are of a binary type such as hex string or byte array. `PyBinary` implements `pyo3::conversion::FromPyObject` and allows the Python user to pass three different Python types:
- `str` (of what should be valid hex, will cause error if not)
- `list[int]` (where int is u8, will cause error if not)
- `bytes` 

This is modeled after `BinaryT` WASM interface type.