### PR TITLE
Py interface cleanup

### DIFF
--- a/consensus/client/src/input.rs
+++ b/consensus/client/src/input.rs
@@ -201,7 +201,6 @@ impl TransactionInput {
     #[getter]
     #[pyo3(name = "signature_script")]
     pub fn get_signature_script_as_hex_py(&self) -> Option<String> {
-        // self.inner().signature_script.to_hex()
         self.inner().signature_script.as_ref().map(|script| script.to_hex())
     }
 

--- a/consensus/client/src/transaction.rs
+++ b/consensus/client/src/transaction.rs
@@ -327,8 +327,8 @@ impl Transaction {
     }
 
     #[pyo3(name = "addresses")]
-    pub fn addresses_py(&self, network_type: String) -> PyResult<Vec<Address>> {
-        let network_type = NetworkType::from_str(&network_type)?;
+    pub fn addresses_py(&self, network_type: &str) -> PyResult<Vec<Address>> {
+        let network_type = NetworkType::from_str(network_type)?;
         let mut list = std::collections::HashSet::new();
         for input in &self.inner.lock().unwrap().inputs {
             if let Some(utxo) = input.get_utxo() {
@@ -400,8 +400,8 @@ impl Transaction {
 
     #[setter]
     #[pyo3(name = "subnetwork_id")]
-    pub fn set_subnetwork_id_from_py_value(&mut self, v: String) {
-        let subnetwork_id = Vec::from_hex(&v)
+    pub fn set_subnetwork_id_from_py_value(&mut self, v: &str) {
+        let subnetwork_id = Vec::from_hex(v)
             .unwrap_or_else(|err| panic!("subnetwork_id decode error {}", err))
             .as_slice()
             .try_into()

--- a/crypto/addresses/src/lib.rs
+++ b/crypto/addresses/src/lib.rs
@@ -276,8 +276,8 @@ impl Address {
 #[pymethods]
 impl Address {
     #[new]
-    pub fn constructor_py(address: &str) -> Address {
-        address.try_into().unwrap_or_else(|err| panic!("Address::constructor() - address error `{}`: {err}", address))
+    pub fn constructor_py(address: &str) -> PyResult<Address> {
+        Ok(address.try_into()?)
     }
 
     #[staticmethod]
@@ -305,8 +305,9 @@ impl Address {
 
     #[setter]
     #[pyo3(name = "prefix")]
-    pub fn set_prefix_from_str_py(&mut self, prefix: &str) {
-        self.prefix = Prefix::try_from(prefix).unwrap_or_else(|err| panic!("Address::prefix() - invalid prefix `{prefix}`: {err}"));
+    pub fn set_prefix_from_str_py(&mut self, prefix: &str) -> PyResult<()> {
+        self.prefix = Prefix::try_from(prefix)?;
+        Ok(())
     }
 
     #[pyo3(name = "payload")]

--- a/crypto/hashes/src/lib.rs
+++ b/crypto/hashes/src/lib.rs
@@ -8,7 +8,7 @@ use kaspa_utils::{
     serde_impl_deser_fixed_bytes_ref, serde_impl_ser_fixed_bytes_ref,
 };
 #[cfg(feature = "py-sdk")]
-use pyo3::prelude::*;
+use pyo3::{exceptions::PyException, prelude::*};
 use std::{
     array::TryFromSliceError,
     fmt::{Debug, Display, Formatter},
@@ -191,8 +191,8 @@ impl Hash {
 #[pymethods]
 impl Hash {
     #[new]
-    pub fn constructor_py(hex_str: &str) -> Self {
-        Hash::from_str(hex_str).expect("invalid hash value")
+    pub fn constructor_py(hex_str: &str) -> PyResult<Self> {
+        Ok(Hash::from_str(hex_str).map_err(|err| PyException::new_err(format!("{}", err)))?)
     }
 
     #[pyo3(name = "to_string")]

--- a/python/core/src/types.rs
+++ b/python/core/src/types.rs
@@ -12,7 +12,7 @@ impl<'a> FromPyObject<'a> for PyBinary {
             // Python `str` (of valid hex)
             let mut data = vec![0u8; str.len() / 2];
             match faster_hex::hex_decode(str.as_bytes(), &mut data) {
-                Ok(()) => Ok(PyBinary { data }), // Hex string
+                Ok(()) => Ok(PyBinary { data }),
                 Err(_) => Err(PyException::new_err("Invalid hex string")),
             }
         } else if let Ok(py_bytes) = value.downcast::<PyBytes>() {

--- a/python/examples/rpc/subscriptions.py
+++ b/python/examples/rpc/subscriptions.py
@@ -4,7 +4,8 @@ from kaspa import RpcClient, Resolver
 
 
 def subscription_callback(event, name, **kwargs):
-    print(event['nonexistent key'])
+    # print(event['nonexistent key'])
+    
     # try:
     #     print(event['nonexistent key'])
     # except KeyError:

--- a/python/examples/rpc/subscriptions.py
+++ b/python/examples/rpc/subscriptions.py
@@ -4,6 +4,12 @@ from kaspa import RpcClient, Resolver
 
 
 def subscription_callback(event, name, **kwargs):
+    print(event['nonexistent key'])
+    # try:
+    #     print(event['nonexistent key'])
+    # except KeyError:
+    #     print('caught key error exception')
+
     print(f"{name} | {event}")
 
 def block_added_handler(event):

--- a/rpc/core/src/api/notifications.rs
+++ b/rpc/core/src/api/notifications.rs
@@ -79,9 +79,9 @@ impl Notification {
             Notification::VirtualDaaScoreChanged(v) => to_pyobject(py, &v),
             Notification::SinkBlueScoreChanged(v) => to_pyobject(py, &v),
             Notification::VirtualChainChanged(v) => to_pyobject(py, &v),
-        };
+        }?;
 
-        Ok(bound_obj.unwrap().to_object(py))
+        Ok(bound_obj.to_object(py))
     }
 }
 

--- a/rpc/macros/src/wrpc/python.rs
+++ b/rpc/macros/src/wrpc/python.rs
@@ -57,7 +57,7 @@ impl ToTokens for RpcHandlers {
                         let py_fut = pyo3_async_runtimes::tokio::future_into_py(py, async move {
                             let response : #response_type = client.#fn_call(None, request).await?;
                             Python::with_gil(|py| {
-                                Ok(serde_pyobject::to_pyobject(py, &response).unwrap().to_object(py))
+                                Ok(serde_pyobject::to_pyobject(py, &response)?.to_object(py))
                             })
                         })?;
 
@@ -83,7 +83,7 @@ impl ToTokens for RpcHandlers {
                             let response : #response_type = client.#fn_call(None, request).await?;
 
                             Python::with_gil(|py| {
-                                Ok(serde_pyobject::to_pyobject(py, &response).unwrap().to_object(py))
+                                Ok(serde_pyobject::to_pyobject(py, &response)?.to_object(py))
                             })
                         })?;
 

--- a/rpc/wrpc/python/src/resolver.rs
+++ b/rpc/wrpc/python/src/resolver.rs
@@ -36,8 +36,8 @@ impl Resolver {
         self.resolver.urls().unwrap_or_default().into_iter().map(|url| (*url).clone()).collect::<Vec<_>>()
     }
 
-    fn get_node(&self, py: Python, encoding: String, network_id: &str) -> PyResult<Py<PyAny>> {
-        let encoding = WrpcEncoding::from_str(encoding.as_str()).unwrap();
+    fn get_node(&self, py: Python, encoding: &str, network_id: &str) -> PyResult<Py<PyAny>> {
+        let encoding = WrpcEncoding::from_str(encoding).unwrap();
         let network_id = NetworkId::from_str(network_id)?;
 
         let resolver = self.resolver.clone();
@@ -49,8 +49,8 @@ impl Resolver {
         }}
     }
 
-    fn get_url(&self, py: Python, encoding: String, network_id: &str) -> PyResult<Py<PyAny>> {
-        let encoding = WrpcEncoding::from_str(encoding.as_str()).unwrap();
+    fn get_url(&self, py: Python, encoding: &str, network_id: &str) -> PyResult<Py<PyAny>> {
+        let encoding = WrpcEncoding::from_str(encoding).unwrap();
         let network_id = NetworkId::from_str(network_id)?;
 
         let resolver = self.resolver.clone();

--- a/wallet/bip32/src/mnemonic/phrase.rs
+++ b/wallet/bip32/src/mnemonic/phrase.rs
@@ -115,7 +115,7 @@ impl Mnemonic {
 impl Mnemonic {
     #[new]
     #[pyo3(signature = (phrase, language=None))]
-    pub fn constructor_py(phrase: String, language: Option<Language>) -> Result<Mnemonic> {
+    pub fn constructor_py(phrase: &str, language: Option<Language>) -> Result<Mnemonic> {
         Mnemonic::new(phrase, language.unwrap_or(Language::English))
     }
 
@@ -134,8 +134,8 @@ impl Mnemonic {
 
     #[setter]
     #[pyo3(name = "entropy")]
-    pub fn set_entropy_py(&mut self, entropy: String) {
-        let vec = Vec::<u8>::from_hex(&entropy).unwrap_or_else(|err| panic!("invalid entropy `{entropy}`: {err}"));
+    pub fn set_entropy_py(&mut self, entropy: &str) {
+        let vec = Vec::<u8>::from_hex(entropy).unwrap_or_else(|err| panic!("invalid entropy `{entropy}`: {err}"));
         let len = vec.len();
         if len != 16 && len != 32 {
             panic!("Invalid entropy: `{entropy}`")
@@ -159,15 +159,15 @@ impl Mnemonic {
 
     #[setter]
     #[pyo3(name = "phrase")]
-    pub fn set_phrase_py(&mut self, phrase: &str) {
-        self.phrase = phrase.to_string();
+    pub fn set_phrase_py(&mut self, phrase: String) {
+        self.phrase = phrase;
     }
 
     #[pyo3(name = "to_seed")]
     #[pyo3(signature = (password=None))]
-    pub fn create_seed_py(&self, password: Option<String>) -> String {
+    pub fn create_seed_py(&self, password: Option<&str>) -> String {
         let password = password.unwrap_or_default();
-        self.to_seed(password.as_str()).as_bytes().to_vec().to_hex()
+        self.to_seed(password).as_bytes().to_vec().to_hex()
     }
 }
 

--- a/wallet/core/src/python/tx/generator/generator.rs
+++ b/wallet/core/src/python/tx/generator/generator.rs
@@ -119,7 +119,7 @@ impl Generator {
         Ok(Self { inner: Arc::new(generator) })
     }
 
-    pub fn estimate(&self) -> Result<GeneratorSummary> {
+    pub fn estimate(&self) -> PyResult<GeneratorSummary> {
         self.inner.iter().collect::<Result<Vec<_>>>()?;
         Ok(self.inner.summary().into())
     }
@@ -202,12 +202,6 @@ impl GeneratorSettings {
         // PY-TODO support GeneratorSource::UtxoContext and clean up below
         let generator_source =
             GeneratorSource::UtxoEntries(entries.iter().map(|entry| UtxoEntryReference::try_from(entry.clone()).unwrap()).collect());
-
-        // let priority_utxo_entries = if let Some(entries) = priority_entries {
-        //     Some(entries.iter().map(|entry| UtxoEntryReference::try_from(entry.clone()).unwrap()).collect())
-        // } else {
-        //     None
-        // };
 
         let sig_op_count = sig_op_count.unwrap_or(1);
 

--- a/wallet/core/src/python/tx/generator/generator.rs
+++ b/wallet/core/src/python/tx/generator/generator.rs
@@ -65,7 +65,7 @@ impl Generator {
     #[new]
     #[pyo3(signature = (network_id, entries, outputs, change_address, payload=None, priority_fee=None, priority_entries=None, sig_op_count=None, minimum_signatures=None))]
     pub fn ctor(
-        network_id: String,
+        network_id: &str,
         entries: PyUtxoEntries,
         outputs: PyOutputs,
         change_address: Address,
@@ -185,9 +185,9 @@ impl GeneratorSettings {
         sig_op_count: Option<u8>,
         minimum_signatures: Option<u16>,
         payload: Option<Vec<u8>>,
-        network_id: String,
+        network_id: &str,
     ) -> GeneratorSettings {
-        let network_id = NetworkId::from_str(&network_id).unwrap();
+        let network_id = NetworkId::from_str(network_id).unwrap();
 
         // PY-TODO
         // let final_transaction_destination: PaymentDestination =

--- a/wallet/core/src/python/tx/generator/pending.rs
+++ b/wallet/core/src/python/tx/generator/pending.rs
@@ -77,7 +77,12 @@ impl PendingTransaction {
     }
 
     #[pyo3(signature = (input_index, private_key, sighash_type=None))]
-    fn create_input_signature(&self, input_index: u8, private_key: &PrivateKey, sighash_type: Option<&SighashType>) -> Result<String> {
+    fn create_input_signature(
+        &self,
+        input_index: u8,
+        private_key: &PrivateKey,
+        sighash_type: Option<&SighashType>,
+    ) -> PyResult<String> {
         let signature = self.inner.create_input_signature(
             input_index.into(),
             &private_key.secret_bytes(),
@@ -87,14 +92,14 @@ impl PendingTransaction {
         Ok(signature.to_hex())
     }
 
-    fn fill_input(&self, input_index: u8, signature_script: PyBinary) -> Result<()> {
+    fn fill_input(&self, input_index: u8, signature_script: PyBinary) -> PyResult<()> {
         self.inner.fill_input(input_index.into(), signature_script.into())?;
 
         Ok(())
     }
 
     #[pyo3(signature = (input_index, private_key, sighash_type=None))]
-    fn sign_input(&self, input_index: u8, private_key: &PrivateKey, sighash_type: Option<&SighashType>) -> Result<()> {
+    fn sign_input(&self, input_index: u8, private_key: &PrivateKey, sighash_type: Option<&SighashType>) -> PyResult<()> {
         self.inner.sign_input(
             input_index.into(),
             &private_key.secret_bytes(),
@@ -105,7 +110,7 @@ impl PendingTransaction {
     }
 
     #[pyo3(signature = (private_keys, check_fully_signed=None))]
-    fn sign(&self, private_keys: Vec<PrivateKey>, check_fully_signed: Option<bool>) -> Result<()> {
+    fn sign(&self, private_keys: Vec<PrivateKey>, check_fully_signed: Option<bool>) -> PyResult<()> {
         let mut keys = private_keys.iter().map(|key| key.secret_bytes()).collect::<Vec<_>>();
         self.inner.try_sign_with_keys(&keys, check_fully_signed)?;
         keys.zeroize();
@@ -123,7 +128,7 @@ impl PendingTransaction {
     }
 
     #[getter]
-    fn transaction(&self) -> Result<Transaction> {
+    fn transaction(&self) -> PyResult<Transaction> {
         Ok(Transaction::from_cctx_transaction(&self.inner.transaction(), self.inner.utxo_entries()))
     }
 }

--- a/wallet/core/src/python/tx/mass.rs
+++ b/wallet/core/src/python/tx/mass.rs
@@ -1,5 +1,4 @@
 use crate::imports::*;
-use crate::result::Result;
 use crate::tx::{mass, MAXIMUM_STANDARD_TRANSACTION_MASS};
 use kaspa_consensus_client::Transaction;
 use kaspa_consensus_core::config::params::Params;
@@ -12,18 +11,18 @@ pub fn maximum_standard_transaction_mass() -> u64 {
 #[pyfunction]
 #[pyo3(name = "calculate_transaction_mass")]
 #[pyo3(signature = (network_id, tx, minimum_signatures=None))]
-pub fn calculate_unsigned_transaction_mass(network_id: &str, tx: &Transaction, minimum_signatures: Option<u16>) -> Result<u64> {
+pub fn calculate_unsigned_transaction_mass(network_id: &str, tx: &Transaction, minimum_signatures: Option<u16>) -> PyResult<u64> {
     let network_id = NetworkId::from_str(network_id)?;
     let consensus_params = Params::from(network_id);
     let network_params = NetworkParams::from(network_id);
     let mc = mass::MassCalculator::new(&consensus_params, &network_params);
-    mc.calc_overall_mass_for_unsigned_client_transaction(tx, minimum_signatures.unwrap_or(1))
+    Ok(mc.calc_overall_mass_for_unsigned_client_transaction(tx, minimum_signatures.unwrap_or(1))?)
 }
 
 #[pyfunction]
 #[pyo3(name = "update_transaction_mass")]
 #[pyo3(signature = (network_id, tx, minimum_signatures=None))]
-pub fn update_unsigned_transaction_mass(network_id: &str, tx: &Transaction, minimum_signatures: Option<u16>) -> Result<bool> {
+pub fn update_unsigned_transaction_mass(network_id: &str, tx: &Transaction, minimum_signatures: Option<u16>) -> PyResult<bool> {
     let network_id = NetworkId::from_str(network_id)?;
     let consensus_params = Params::from(network_id);
     let network_params = NetworkParams::from(network_id);
@@ -40,7 +39,11 @@ pub fn update_unsigned_transaction_mass(network_id: &str, tx: &Transaction, mini
 #[pyfunction]
 #[pyo3(name = "calculate_transaction_fee")]
 #[pyo3(signature = (network_id, tx, minimum_signatures=None))]
-pub fn calculate_unsigned_transaction_fee(network_id: &str, tx: &Transaction, minimum_signatures: Option<u16>) -> Result<Option<u64>> {
+pub fn calculate_unsigned_transaction_fee(
+    network_id: &str,
+    tx: &Transaction,
+    minimum_signatures: Option<u16>,
+) -> PyResult<Option<u64>> {
     let network_id = NetworkId::from_str(network_id)?;
     let consensus_params = Params::from(network_id);
     let network_params = NetworkParams::from(network_id);

--- a/wallet/core/src/python/tx/utils.rs
+++ b/wallet/core/src/python/tx/utils.rs
@@ -46,7 +46,7 @@ pub fn create_transaction_py(
 #[pyo3(signature = (network_id, entries, outputs, change_address, payload=None, priority_fee=None, priority_entries=None, sig_op_count=None, minimum_signatures=None))]
 pub fn create_transactions_py<'a>(
     py: Python<'a>,
-    network_id: String,
+    network_id: &str,
     entries: PyUtxoEntries,
     outputs: PyOutputs,
     change_address: Address,
@@ -81,7 +81,7 @@ pub fn create_transactions_py<'a>(
 #[pyo3(name = "estimate_transactions")]
 #[pyo3(signature = (network_id, entries, outputs, change_address, payload=None, priority_fee=None, priority_entries=None, sig_op_count=None, minimum_signatures=None))]
 pub fn estimate_transactions_py<'a>(
-    network_id: String,
+    network_id: &str,
     entries: PyUtxoEntries,
     outputs: PyOutputs,
     change_address: Address,

--- a/wallet/keys/src/derivation_path.rs
+++ b/wallet/keys/src/derivation_path.rs
@@ -56,7 +56,7 @@ impl DerivationPath {
 #[pymethods]
 impl DerivationPath {
     #[new]
-    pub fn new_py(path: &str) -> Result<DerivationPath> {
+    pub fn new_py(path: &str) -> PyResult<DerivationPath> {
         let inner = kaspa_bip32::DerivationPath::from_str(path)?;
         Ok(Self { inner })
     }
@@ -78,7 +78,7 @@ impl DerivationPath {
 
     #[pyo3(name = "push")]
     #[pyo3(signature = (child_number, hardened=None))]
-    pub fn push_py(&mut self, child_number: u32, hardened: Option<bool>) -> Result<()> {
+    pub fn push_py(&mut self, child_number: u32, hardened: Option<bool>) -> PyResult<()> {
         let child = ChildNumber::new(child_number, hardened.unwrap_or(false))?;
         self.inner.push(child);
         Ok(())

--- a/wallet/keys/src/keypair.rs
+++ b/wallet/keys/src/keypair.rs
@@ -147,7 +147,7 @@ impl Keypair {
     pub fn from_private_key_py(secret_key: &PrivateKey) -> PyResult<Keypair> {
         let secp = Secp256k1::new();
         let secret_key =
-            secp256k1::SecretKey::from_slice(&secret_key.secret_bytes()).map_err(|e| PyErr::new::<PyException, _>(format!("{e}")))?;
+            secp256k1::SecretKey::from_slice(&secret_key.secret_bytes()).map_err(|e| PyException::new_err(format!("{e}")))?;
         let public_key = secp256k1::PublicKey::from_secret_key(&secp, &secret_key);
         let (xonly_public_key, _) = public_key.x_only_public_key();
         Ok(Keypair::new(secret_key, public_key, xonly_public_key))

--- a/wallet/keys/src/privatekey.rs
+++ b/wallet/keys/src/privatekey.rs
@@ -98,8 +98,9 @@ impl PrivateKey {
 #[pymethods]
 impl PrivateKey {
     #[new]
-    pub fn try_new_py(key: &str) -> Result<PrivateKey> {
-        Ok(Self { inner: secp256k1::SecretKey::from_str(key)? })
+    pub fn try_new_py(key: &str) -> PyResult<PrivateKey> {
+        let secret_key = secp256k1::SecretKey::from_str(key).map_err(|err| PyException::new_err(format!("{}", err)))?;
+        Ok(Self { inner: secret_key })
     }
 
     #[pyo3(name = "to_string")]

--- a/wallet/keys/src/privkeygen.rs
+++ b/wallet/keys/src/privkeygen.rs
@@ -62,7 +62,7 @@ impl PrivateKeyGenerator {
 impl PrivateKeyGenerator {
     #[new]
     #[pyo3(signature = (xprv, is_multisig, account_index, cosigner_index=None))]
-    pub fn new_py(xprv: String, is_multisig: bool, account_index: u64, cosigner_index: Option<u32>) -> Result<PrivateKeyGenerator> {
+    pub fn new_py(xprv: String, is_multisig: bool, account_index: u64, cosigner_index: Option<u32>) -> PyResult<PrivateKeyGenerator> {
         let xprv = XPrv::from_xprv_str(xprv)?;
         let xprv = xprv.inner();
         let receive = xprv.clone().derive_path(&WalletDerivationManager::build_derivate_path(

--- a/wallet/keys/src/pubkeygen.rs
+++ b/wallet/keys/src/pubkeygen.rs
@@ -298,7 +298,7 @@ impl PublicKeyGenerator {
     }
 
     #[pyo3(name = "receive_addresses_as_strings")]
-    fn receive_addresses_as_strings_py(&self, network_type: &str, mut start: u32, mut end: u32) -> Result<Vec<String>> {
+    fn receive_addresses_as_strings_py(&self, network_type: &str, mut start: u32, mut end: u32) -> PyResult<Vec<String>> {
         if start > end {
             (start, end) = (end, start);
         }
@@ -310,7 +310,7 @@ impl PublicKeyGenerator {
     }
 
     #[pyo3(name = "receive_address_as_string")]
-    fn receive_address_as_string_py(&self, network_type: &str, index: u32) -> Result<String> {
+    fn receive_address_as_string_py(&self, network_type: &str, index: u32) -> PyResult<String> {
         Ok(PublicKey::from(self.hd_wallet.receive_pubkey_manager().derive_pubkey(index)?)
             .to_address(NetworkType::from_str(network_type)?)?
             .to_string())
@@ -382,7 +382,7 @@ impl PublicKeyGenerator {
     }
 
     #[pyo3(name = "to_string")]
-    pub fn to_string_py(&self) -> Result<String> {
+    pub fn to_string_py(&self) -> PyResult<String> {
         Ok(self.hd_wallet.to_string(None).to_string())
     }
 }

--- a/wallet/keys/src/pubkeygen.rs
+++ b/wallet/keys/src/pubkeygen.rs
@@ -228,8 +228,8 @@ impl PublicKeyGenerator {
     #[staticmethod]
     #[pyo3(name = "from_xpub")]
     #[pyo3(signature = (kpub, cosigner_index=None))]
-    fn from_xpub_py(kpub: String, cosigner_index: Option<u32>) -> PyResult<PublicKeyGenerator> {
-        let kpub = XPub::try_new(kpub.as_str())?;
+    fn from_xpub_py(kpub: &str, cosigner_index: Option<u32>) -> PyResult<PublicKeyGenerator> {
+        let kpub = XPub::try_new(kpub)?;
         let xpub = kpub.inner();
         let hd_wallet = WalletDerivationManager::from_extended_public_key(xpub.clone(), cosigner_index)?;
         Ok(Self { hd_wallet })
@@ -280,11 +280,11 @@ impl PublicKeyGenerator {
     }
 
     #[pyo3(name = "receive_addresses")]
-    fn receive_addresses_py(&self, network_type: String, mut start: u32, mut end: u32) -> PyResult<Vec<Address>> {
+    fn receive_addresses_py(&self, network_type: &str, mut start: u32, mut end: u32) -> PyResult<Vec<Address>> {
         if start > end {
             (start, end) = (end, start);
         }
-        let network_type = NetworkType::from_str(&network_type)?;
+        let network_type = NetworkType::from_str(network_type)?;
         let pubkeys = self.hd_wallet.receive_pubkey_manager().derive_pubkey_range(start..end)?;
         let addresses =
             pubkeys.into_iter().map(|pk| PublicKey::from(pk).to_address(network_type)).collect::<Result<Vec<Address>>>()?;
@@ -292,17 +292,17 @@ impl PublicKeyGenerator {
     }
 
     #[pyo3(name = "receive_address")]
-    fn receive_address_py(&self, network_type: String, index: u32) -> PyResult<Address> {
-        let network_type = NetworkType::from_str(&network_type)?;
+    fn receive_address_py(&self, network_type: &str, index: u32) -> PyResult<Address> {
+        let network_type = NetworkType::from_str(network_type)?;
         Ok(PublicKey::from(self.hd_wallet.receive_pubkey_manager().derive_pubkey(index)?).to_address(network_type)?)
     }
 
     #[pyo3(name = "receive_addresses_as_strings")]
-    fn receive_addresses_as_strings_py(&self, network_type: String, mut start: u32, mut end: u32) -> Result<Vec<String>> {
+    fn receive_addresses_as_strings_py(&self, network_type: &str, mut start: u32, mut end: u32) -> Result<Vec<String>> {
         if start > end {
             (start, end) = (end, start);
         }
-        let network_type = NetworkType::from_str(&network_type)?;
+        let network_type = NetworkType::from_str(network_type)?;
         let pubkeys = self.hd_wallet.receive_pubkey_manager().derive_pubkey_range(start..end)?;
         let addresses =
             pubkeys.into_iter().map(|pk| PublicKey::from(pk).to_address(network_type)).collect::<Result<Vec<Address>>>()?;
@@ -310,9 +310,9 @@ impl PublicKeyGenerator {
     }
 
     #[pyo3(name = "receive_address_as_string")]
-    fn receive_address_as_string_py(&self, network_type: String, index: u32) -> Result<String> {
+    fn receive_address_as_string_py(&self, network_type: &str, index: u32) -> Result<String> {
         Ok(PublicKey::from(self.hd_wallet.receive_pubkey_manager().derive_pubkey(index)?)
-            .to_address(NetworkType::from_str(&network_type)?)?
+            .to_address(NetworkType::from_str(network_type)?)?
             .to_string())
     }
 
@@ -345,11 +345,11 @@ impl PublicKeyGenerator {
     }
 
     #[pyo3(name = "change_addresses")]
-    pub fn change_addresses_py(&self, network_type: String, mut start: u32, mut end: u32) -> PyResult<Vec<Address>> {
+    pub fn change_addresses_py(&self, network_type: &str, mut start: u32, mut end: u32) -> PyResult<Vec<Address>> {
         if start > end {
             (start, end) = (end, start);
         }
-        let network_type = NetworkType::from_str(&network_type)?;
+        let network_type = NetworkType::from_str(network_type)?;
         let pubkeys = self.hd_wallet.change_pubkey_manager().derive_pubkey_range(start..end)?;
         let addresses =
             pubkeys.into_iter().map(|pk| PublicKey::from(pk).to_address(network_type)).collect::<Result<Vec<Address>>>()?;
@@ -357,17 +357,17 @@ impl PublicKeyGenerator {
     }
 
     #[pyo3(name = "change_address")]
-    pub fn change_address_py(&self, network_type: String, index: u32) -> PyResult<Address> {
-        let network_type = NetworkType::from_str(&network_type)?;
+    pub fn change_address_py(&self, network_type: &str, index: u32) -> PyResult<Address> {
+        let network_type = NetworkType::from_str(network_type)?;
         Ok(PublicKey::from(self.hd_wallet.change_pubkey_manager().derive_pubkey(index)?).to_address(network_type)?)
     }
 
     #[pyo3(name = "change_addresses_as_strings")]
-    pub fn change_addresses_as_strings_py(&self, network_type: String, mut start: u32, mut end: u32) -> PyResult<Vec<String>> {
+    pub fn change_addresses_as_strings_py(&self, network_type: &str, mut start: u32, mut end: u32) -> PyResult<Vec<String>> {
         if start > end {
             (start, end) = (end, start);
         }
-        let network_type = NetworkType::from_str(network_type.as_str())?;
+        let network_type = NetworkType::from_str(network_type)?;
         let pubkeys = self.hd_wallet.change_pubkey_manager().derive_pubkey_range(start..end)?;
         let addresses =
             pubkeys.into_iter().map(|pk| PublicKey::from(pk).to_address(network_type)).collect::<Result<Vec<Address>>>()?;
@@ -375,9 +375,9 @@ impl PublicKeyGenerator {
     }
 
     #[pyo3(name = "change_address_as_string")]
-    pub fn change_address_as_string_py(&self, network_type: String, index: u32) -> PyResult<String> {
+    pub fn change_address_as_string_py(&self, network_type: &str, index: u32) -> PyResult<String> {
         Ok(PublicKey::from(self.hd_wallet.receive_pubkey_manager().derive_pubkey(index)?)
-            .to_address(NetworkType::from_str(network_type.as_str())?)?
+            .to_address(NetworkType::from_str(network_type)?)?
             .to_string())
     }
 

--- a/wallet/keys/src/publickey.rs
+++ b/wallet/keys/src/publickey.rs
@@ -91,10 +91,11 @@ impl PublicKey {
 #[pymethods]
 impl PublicKey {
     #[new]
-    pub fn try_new_py(key: &str) -> Result<PublicKey> {
+    pub fn try_new_py(key: &str) -> PyResult<PublicKey> {
+        let xonly_public_key = secp256k1::XOnlyPublicKey::from_str(key).map_err(|err| PyException::new_err(format!("{}", err)))?;
         match secp256k1::PublicKey::from_str(key) {
             Ok(public_key) => Ok((&public_key).into()),
-            Err(_e) => Ok(Self { xonly_public_key: secp256k1::XOnlyPublicKey::from_str(key)?, public_key: None }),
+            Err(_e) => Ok(Self { xonly_public_key, public_key: None }),
         }
     }
 
@@ -104,13 +105,13 @@ impl PublicKey {
     }
 
     #[pyo3(name = "to_address")]
-    pub fn to_address_py(&self, network: &str) -> Result<Address> {
-        self.to_address(NetworkType::from_str(network)?)
+    pub fn to_address_py(&self, network: &str) -> PyResult<Address> {
+        Ok(self.to_address(NetworkType::from_str(network)?)?)
     }
 
     #[pyo3(name = "to_address_ecdsa")]
-    pub fn to_address_ecdsa_py(&self, network: &str) -> Result<Address> {
-        self.to_address_ecdsa(NetworkType::from_str(network)?)
+    pub fn to_address_ecdsa_py(&self, network: &str) -> PyResult<Address> {
+        Ok(self.to_address_ecdsa(NetworkType::from_str(network)?)?)
     }
 
     #[pyo3(name = "to_x_only_public_key")]
@@ -293,8 +294,9 @@ impl XOnlyPublicKey {
 #[pymethods]
 impl XOnlyPublicKey {
     #[new]
-    pub fn try_new_py(key: &str) -> Result<XOnlyPublicKey> {
-        Ok(secp256k1::XOnlyPublicKey::from_str(key)?.into())
+    pub fn try_new_py(key: &str) -> PyResult<XOnlyPublicKey> {
+        let xonly_public_key = secp256k1::XOnlyPublicKey::from_str(key).map_err(|err| PyException::new_err(format!("{}", err)))?;
+        Ok(xonly_public_key.into())
     }
 
     #[pyo3(name = "to_string")]
@@ -318,8 +320,10 @@ impl XOnlyPublicKey {
 
     #[pyo3(name = "from_address")]
     #[staticmethod]
-    pub fn from_address_py(address: &Address) -> Result<XOnlyPublicKey> {
-        Ok(secp256k1::XOnlyPublicKey::from_slice(&address.payload)?.into())
+    pub fn from_address_py(address: &Address) -> PyResult<XOnlyPublicKey> {
+        let xonly_public_key =
+            secp256k1::XOnlyPublicKey::from_slice(&address.payload).map_err(|err| PyException::new_err(format!("{}", err)))?;
+        Ok(xonly_public_key.into())
     }
 }
 

--- a/wallet/keys/src/publickey.rs
+++ b/wallet/keys/src/publickey.rs
@@ -92,10 +92,13 @@ impl PublicKey {
 impl PublicKey {
     #[new]
     pub fn try_new_py(key: &str) -> PyResult<PublicKey> {
-        let xonly_public_key = secp256k1::XOnlyPublicKey::from_str(key).map_err(|err| PyException::new_err(format!("{}", err)))?;
         match secp256k1::PublicKey::from_str(key) {
             Ok(public_key) => Ok((&public_key).into()),
-            Err(_e) => Ok(Self { xonly_public_key, public_key: None }),
+            Err(_) => {
+                let xonly_public_key =
+                    secp256k1::XOnlyPublicKey::from_str(key).map_err(|err| PyException::new_err(format!("{}", err)))?;
+                Ok(Self { xonly_public_key, public_key: None })
+            }
         }
     }
 

--- a/wallet/keys/src/xprv.rs
+++ b/wallet/keys/src/xprv.rs
@@ -133,8 +133,8 @@ impl XPrv {
 #[pymethods]
 impl XPrv {
     #[new]
-    fn try_new_py(seed: String) -> PyResult<XPrv> {
-        let seed_bytes = Vec::<u8>::from_hex(&seed).map_err(|e| PyErr::new::<PyException, _>(format!("{}", e)))?;
+    fn try_new_py(seed: &str) -> PyResult<XPrv> {
+        let seed_bytes = Vec::<u8>::from_hex(seed).map_err(|e| PyErr::new::<PyException, _>(format!("{}", e)))?;
 
         let inner = ExtendedPrivateKey::<SecretKey>::new(seed_bytes)?;
         Ok(Self { inner })
@@ -142,8 +142,8 @@ impl XPrv {
 
     #[staticmethod]
     #[pyo3(name = "from_xprv")]
-    pub fn from_xprv_str_py(xprv: String) -> PyResult<XPrv> {
-        Ok(Self { inner: ExtendedPrivateKey::<SecretKey>::from_str(&xprv)? })
+    pub fn from_xprv_str_py(xprv: &str) -> PyResult<XPrv> {
+        Ok(Self { inner: ExtendedPrivateKey::<SecretKey>::from_str(xprv)? })
     }
 
     #[pyo3(name = "derive_child")]

--- a/wallet/keys/src/xpub.rs
+++ b/wallet/keys/src/xpub.rs
@@ -124,7 +124,7 @@ impl XPub {
     }
 
     #[pyo3(name = "into_string")]
-    pub fn to_str_py(&self, prefix: &str) -> Result<String> {
+    pub fn to_str_py(&self, prefix: &str) -> PyResult<String> {
         Ok(self.inner.to_string(Some(prefix.try_into()?)))
     }
 

--- a/wallet/keys/src/xpub.rs
+++ b/wallet/keys/src/xpub.rs
@@ -103,8 +103,8 @@ impl XPub {
 #[pymethods]
 impl XPub {
     #[new]
-    pub fn try_new_py(xpub: String) -> PyResult<XPub> {
-        let inner = ExtendedPublicKey::<secp256k1::PublicKey>::from_str(&xpub)?;
+    pub fn try_new_py(xpub: &str) -> PyResult<XPub> {
+        let inner = ExtendedPublicKey::<secp256k1::PublicKey>::from_str(xpub)?;
         Ok(Self { inner })
     }
 
@@ -117,8 +117,8 @@ impl XPub {
     }
 
     #[pyo3(name = "derive_path")]
-    pub fn derive_path_py(&self, path: String) -> PyResult<XPub> {
-        let path = DerivationPath::new(path.as_str())?;
+    pub fn derive_path_py(&self, path: &str) -> PyResult<XPub> {
+        let path = DerivationPath::new(path)?;
         let inner = self.inner.clone().derive_path((&path).into())?;
         Ok(Self { inner })
     }


### PR DESCRIPTION
- `String` vs `&str` in functions exposed 
- Replace all `Result` with `PyResult`
- Prop errors where possible
- `map_err()` cleanup
- Remove `unwrap()` where possible
- RPC subscription print python stack trace if execution of python callback from Rust yields exception