### PR TITLE
Wallet API support for atomic commit reveal transaction.

### DIFF
--- a/wallet/core/src/api/message.rs
+++ b/wallet/core/src/api/message.rs
@@ -668,3 +668,69 @@ pub struct AddressBookEnumerateResponse {}
 #[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WalletNotification {}
+
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountsCommitRevealManualRequest {
+    pub account_id: AccountId,
+    pub script_sig: Vec<u8>,
+    pub start_destination: PaymentDestination,
+    pub end_destination: PaymentDestination,
+    pub wallet_secret: Secret,
+    pub payment_secret: Option<Secret>,
+    pub fee_rate: Option<f64>,
+    pub priority_fees_sompi: Option<Vec<Fees>>,
+    pub payload: Option<Vec<u8>>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountsCommitRevealManualResponse {
+    pub transaction_ids: Vec<TransactionId>,
+}
+
+/// Specifies the type of an account address to be used in
+/// commit reveal redeem script and also to spend reveal
+/// operation to.
+///
+/// @category Wallet API
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, CastFromJs)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "wasm32-sdk", wasm_bindgen)]
+pub enum CommitRevealAddressKind {
+    Receive,
+    Change,
+}
+
+impl FromStr for CommitRevealAddressKind {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "receive" => Ok(CommitRevealAddressKind::Receive),
+            "change" => Ok(CommitRevealAddressKind::Change),
+            _ => Err(Error::custom(format!("Invalid address kind: {s}"))),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountsCommitRevealRequest {
+    pub account_id: AccountId,
+    pub address_type: CommitRevealAddressKind,
+    pub address_index: u32,
+    pub script_sig: Vec<u8>,
+    pub wallet_secret: Secret,
+    pub commit_amount_sompi: u64,
+    pub payment_secret: Option<Secret>,
+    pub fee_rate: Option<f64>,
+    pub priority_fees_sompi: Option<Vec<Fees>>,
+    pub payload: Option<Vec<u8>>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountsCommitRevealResponse {
+    pub transaction_ids: Vec<TransactionId>,
+}

--- a/wallet/core/src/api/traits.rs
+++ b/wallet/core/src/api/traits.rs
@@ -422,6 +422,26 @@ pub trait WalletApi: Send + Sync + AnySync {
     /// available immediately upon transaction acceptance.
     async fn accounts_transfer_call(self: Arc<Self>, request: AccountsTransferRequest) -> Result<AccountsTransferResponse>;
 
+    /// Commit-reveal funds using provided [`PaymentDestination`] in
+    /// [`AccountsCommitRevealManualRequest`].
+    /// Returns an [`AccountsCommitRevealManualResponse`] struct that
+    /// contains transaction ids.
+    async fn accounts_commit_reveal_manual_call(
+        self: Arc<Self>,
+        request: AccountsCommitRevealManualRequest,
+    ) -> Result<AccountsCommitRevealManualResponse>;
+
+    /// Commit-reveal funds to P2SH of given script signature present in
+    /// [`AccountsCommitRevealRequest`] that provides a pubkey placeholder
+    /// used by given address type and address index looked up in derivation
+    /// manager.
+    /// Returns an [`AccountsCommitRevealResponse`] struct that contains
+    /// transaction ids.
+    async fn accounts_commit_reveal_call(
+        self: Arc<Self>,
+        request: AccountsCommitRevealRequest,
+    ) -> Result<AccountsCommitRevealResponse>;
+
     /// Performs a transaction estimate, returning [`AccountsEstimateResponse`]
     /// that contains [`GeneratorSummary`]. This call will estimate the total
     /// amount of fees that will be required by the transaction as well as

--- a/wallet/core/src/api/transport.rs
+++ b/wallet/core/src/api/transport.rs
@@ -108,6 +108,8 @@ impl WalletApi for WalletClient {
         FeeRateEstimate,
         FeeRatePollerEnable,
         FeeRatePollerDisable,
+        AccountsCommitReveal,
+        AccountsCommitRevealManual,
     ]}
 }
 
@@ -188,6 +190,8 @@ impl WalletServer {
         FeeRateEstimate,
         FeeRatePollerEnable,
         FeeRatePollerDisable,
+        AccountsCommitReveal,
+        AccountsCommitRevealManual,
     ]}
 }
 

--- a/wallet/core/src/error.rs
+++ b/wallet/core/src/error.rs
@@ -347,6 +347,9 @@ pub enum Error {
 
     #[error("Address not found")]
     AddressNotFound,
+
+    #[error("Something went wrong while generating commit reveal transaction batch")]
+    CommitRevealBatchGeneratorError,
 }
 
 impl From<Aborted> for Error {

--- a/wallet/core/src/wasm/api/mod.rs
+++ b/wallet/core/src/wasm/api/mod.rs
@@ -55,4 +55,6 @@ declare_wasm_handlers!([
     FeeRateEstimate,
     FeeRatePollerEnable,
     FeeRatePollerDisable,
+    AccountsCommitReveal,
+    AccountsCommitRevealManual,
 ]);


### PR DESCRIPTION
Reviewed merge with JS API documentation and potential ToDos.

Note: Functions to get address index have been added. Though they can be superseded by functions of another PR once implemented/todo finalized.