### PR TITLE
Simplify API wallet commit reveal fee.

### DIFF
--- a/wallet/core/src/account/mod.rs
+++ b/wallet/core/src/account/mod.rs
@@ -389,13 +389,13 @@ pub trait Account: AnySync + Send + Sync + 'static {
         wallet_secret: Secret,
         payment_secret: Option<Secret>,
         fee_rate: Option<f64>,
-        priority_fees_sompi: Option<Vec<u64>>,
+        reveal_fee_sompi: Option<u64>,
         payload: Option<Vec<u8>>,
         abortable: &Abortable,
     ) -> Result<Bundle, Error> {
         commit_reveal_batch_bundle(
             pskb::CommitRevealBatchKind::Manual { hop_payment: start_destination, destination_payment: end_destination },
-            priority_fees_sompi,
+            reveal_fee_sompi,
             script_sig,
             payload,
             fee_rate,
@@ -415,13 +415,13 @@ pub trait Account: AnySync + Send + Sync + 'static {
         payment_secret: Option<Secret>,
         commit_amount_sompi: u64,
         fee_rate: Option<f64>,
-        priority_fees_sompi: Option<Vec<u64>>,
+        reveal_fee_sompi: Option<u64>,
         payload: Option<Vec<u8>>,
         abortable: &Abortable,
     ) -> Result<Bundle, Error> {
         commit_reveal_batch_bundle(
             pskb::CommitRevealBatchKind::Parameterized { address, commit_amount_sompi },
-            priority_fees_sompi,
+            reveal_fee_sompi,
             script_sig,
             payload,
             fee_rate,

--- a/wallet/core/src/account/pskb.rs
+++ b/wallet/core/src/account/pskb.rs
@@ -384,7 +384,7 @@ struct BundleCommitRevealConfig {
     pub address_reveal: Address,
     pub first_output: PaymentDestination,
     pub commit_fee: Option<u64>,
-    pub reveal_fee: Option<u64>,
+    pub reveal_fee: u64,
     pub redeem_script: Vec<u8>,
 }
 
@@ -392,7 +392,7 @@ struct BundleCommitRevealConfig {
 // Default reveal fee of 100_000 sompi if priority_fee_sompi is not provided.
 pub async fn commit_reveal_batch_bundle(
     batch_config: CommitRevealBatchKind,
-    priority_fee_sompi: Option<Vec<u64>>,
+    reveal_fee_sompi: Option<u64>,
     script_sig: Vec<u8>,
     payload: Option<Vec<u8>>,
     fee_rate: Option<f64>,
@@ -424,7 +424,7 @@ pub async fn commit_reveal_batch_bundle(
                 address_reveal: addr_reveal,
                 first_output: hop_payment,
                 commit_fee: None,
-                reveal_fee: None,
+                reveal_fee: 100_000,
                 redeem_script: script_sig,
             }
         }
@@ -436,7 +436,7 @@ pub async fn commit_reveal_batch_bundle(
                 address_reveal: address.clone(),
                 first_output: PaymentDestination::from(PaymentOutput::new(lock_address, commit_amount_sompi)),
                 commit_fee: None,
-                reveal_fee: None,
+                reveal_fee: 100_000,
                 redeem_script,
             }
         }
@@ -447,8 +447,9 @@ pub async fn commit_reveal_batch_bundle(
     // respectively be applied to commit and reveal transaction.
     //
     // A default minimum reveal transaction fee is set to 1000_000.
-    conf.commit_fee = priority_fee_sompi.clone().and_then(|v| v.into_iter().next());
-    conf.reveal_fee = priority_fee_sompi.and_then(|v| v.into_iter().nth(1)).or(conf.commit_fee).or(Some(100_000));
+    // conf.commit_fee = priority_fee_sompi.clone().and_then(|v| v.into_iter().next());
+    // conf.reveal_fee = priority_fee_sompi.and_then(|v| v.into_iter().nth(1)).or(conf.commit_fee).or(Some(100_000));
+    conf.reveal_fee = reveal_fee_sompi.unwrap_or(100_000);
 
     // Generate commit transaction.
     let settings = GeneratorSettings::try_new_with_account(
@@ -476,7 +477,7 @@ pub async fn commit_reveal_batch_bundle(
         &conf.address_commit,
         &conf.address_reveal,
         &conf.redeem_script,
-        conf.reveal_fee,
+        Some(conf.reveal_fee),
     )?;
 
     let mut merge_bundle: Option<Bundle> = None;

--- a/wallet/core/src/account/pskb.rs
+++ b/wallet/core/src/account/pskb.rs
@@ -389,7 +389,7 @@ struct BundleCommitRevealConfig {
 }
 
 // Create signed atomic commit reveal PSKB.
-// Default reveal fee of 100_000 sompi if priority_fee_sompi is not provided.
+// Default reveal_fee_sompi: 100_000 sompi if not provided.
 pub async fn commit_reveal_batch_bundle(
     batch_config: CommitRevealBatchKind,
     reveal_fee_sompi: Option<u64>,
@@ -442,13 +442,8 @@ pub async fn commit_reveal_batch_bundle(
         }
     };
 
-    // Up to two optional priority fees can be set: if only the first one is set, it will
-    // be applied to both transactions, whereas if both fees are set they will
-    // respectively be applied to commit and reveal transaction.
-    //
-    // A default minimum reveal transaction fee is set to 1000_000.
-    // conf.commit_fee = priority_fee_sompi.clone().and_then(|v| v.into_iter().next());
-    // conf.reveal_fee = priority_fee_sompi.and_then(|v| v.into_iter().nth(1)).or(conf.commit_fee).or(Some(100_000));
+    // A default minimum reveal transaction fee is set to 100_000.
+    // todo: rebase on mass.
     conf.reveal_fee = reveal_fee_sompi.unwrap_or(100_000);
 
     // Generate commit transaction.
@@ -471,7 +466,7 @@ pub async fn commit_reveal_batch_bundle(
 
     // Generate reveal transaction
 
-    // todo: support priority fee.
+    // todo: support minimal fee by mass computation when no reveal fee is provided.
     let bundle_unlock = unlock_utxo_as_batch_transaction_pskb(
         conf.first_output.amount().unwrap(),
         &conf.address_commit,

--- a/wallet/core/src/api/message.rs
+++ b/wallet/core/src/api/message.rs
@@ -679,7 +679,7 @@ pub struct AccountsCommitRevealManualRequest {
     pub wallet_secret: Secret,
     pub payment_secret: Option<Secret>,
     pub fee_rate: Option<f64>,
-    pub priority_fees_sompi: Option<Vec<Fees>>,
+    pub reveal_fee_sompi: Option<u64>,
     pub payload: Option<Vec<u8>>,
 }
 
@@ -725,7 +725,7 @@ pub struct AccountsCommitRevealRequest {
     pub commit_amount_sompi: u64,
     pub payment_secret: Option<Secret>,
     pub fee_rate: Option<f64>,
-    pub priority_fees_sompi: Option<Vec<Fees>>,
+    pub reveal_fee_sompi: Option<u64>,
     pub payload: Option<Vec<u8>>,
 }
 

--- a/wallet/core/src/wallet/api.rs
+++ b/wallet/core/src/wallet/api.rs
@@ -453,7 +453,7 @@ impl WalletApi for super::Wallet {
             wallet_secret,
             payment_secret,
             fee_rate,
-            priority_fees_sompi,
+            reveal_fee_sompi,
             payload,
         } = request;
 
@@ -464,8 +464,6 @@ impl WalletApi for super::Wallet {
 
         let abortable = Abortable::new();
 
-        let priority_fees: Option<Vec<u64>> = priority_fees_sompi.map(|v| v.iter().map(|f| f.additional()).collect());
-
         let bundle = account
             .clone()
             .commit_reveal_manual(
@@ -475,7 +473,7 @@ impl WalletApi for super::Wallet {
                 wallet_secret,
                 payment_secret,
                 fee_rate,
-                priority_fees,
+                reveal_fee_sompi,
                 payload,
                 &abortable,
             )
@@ -498,7 +496,7 @@ impl WalletApi for super::Wallet {
             wallet_secret,
             payment_secret,
             fee_rate,
-            priority_fees_sompi,
+            reveal_fee_sompi,
             payload,
         } = request;
 
@@ -516,8 +514,6 @@ impl WalletApi for super::Wallet {
 
         let abortable = Abortable::new();
 
-        let priority_fees: Option<Vec<u64>> = priority_fees_sompi.map(|v| v.iter().map(|f| f.additional()).collect());
-
         let bundle = account
             .clone()
             .commit_reveal(
@@ -527,7 +523,7 @@ impl WalletApi for super::Wallet {
                 payment_secret,
                 commit_amount_sompi,
                 fee_rate,
-                priority_fees,
+                reveal_fee_sompi,
                 payload,
                 &abortable,
             )

--- a/wallet/core/src/wasm/api/message.rs
+++ b/wallet/core/src/wasm/api/message.rs
@@ -1886,6 +1886,7 @@ declare! {
      * 
      * The selected address will also be used to spend reveal transaction to.
      * 
+     * The default revealFeeSompi is 100_000 sompi.
      *  
      * @category Wallet API
      */
@@ -1973,6 +1974,11 @@ declare! {
      * 
      * The scriptSig will be used to spend the UTXO of the first transaction and
      * must therefore match the startDestination output P2SH.
+     * 
+     * Set revealFeeSompi or reflect the reveal fee transaction on endDestination
+     * output amount. 
+     * 
+     * The default revealFeeSompi is 100_000 sompi.
      * 
      * @category Wallet API
      */

--- a/wallet/core/src/wasm/api/message.rs
+++ b/wallet/core/src/wasm/api/message.rs
@@ -1920,7 +1920,7 @@ try_from! ( args: IAccountsCommitRevealRequest, AccountsCommitRevealRequest, {
     let payment_secret = args.try_get_secret("paymentSecret")?;
     let commit_amount_sompi = args.get_u64("commitAmountSompi")?;
     let fee_rate = args.get_f64("feeRate").ok();
-    
+
     let reveal_fee_sompi = args.get_u64("revealFeeSompi").ok();
 
     let payload = args.try_get_value("payload")?.map(|v| v.try_as_vec_u8()).transpose()?;


### PR DESCRIPTION
This had to be done for usability.