### PR TITLE
Python packaging & CI clean up

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -425,5 +425,5 @@ jobs:
         with:
           working-directory: python
           target: x86_64
-          args: --release --strip --out target/dist --features py-sdk --interpreter python3.12
+          args: --release --strip --out target/dist --interpreter python3.12
           manylinux: auto

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -213,11 +213,11 @@ jobs:
             # ring crate 0.17 fails to build for aarch64 using manylinux: auto, hence manylinux_2_28
             manylinux: manylinux_2_28
           - runner: macos-latest
-            target: x86_64-apple-darwin
+            target: x86_64
           - runner: macos-latest
-            target: aarch64-apple-darwin
+            target: aarch64
           - runner: windows-latest
-            target: x64
+            target: x86_64
           # - runner: windows-latest
           #   target: x86
     steps:
@@ -226,7 +226,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '>=3.10 <3.13'
+          python-version: '>=3.11 <=3.13'
       
       - name: Install cross-compilation tools (Linux only)
         if: runner.os == 'Linux' && matrix.platform.target != 'x86_64'
@@ -250,6 +250,7 @@ jobs:
           manylinux: ${{ matrix.platform.manylinux || '' }}
 
       - name: Build sdist
+        if: runner.os == 'Linux' && matrix.platform.target == 'x86_64'
         uses: PyO3/maturin-action@v1
         with:
           working-directory: python
@@ -274,7 +275,7 @@ jobs:
       - name: Zip artifacts
         run: |
           cd artifacts
-          sudo zip -r ../kaspa-python-sdk.zip .
+          zip -r ../kaspa-python-sdk.zip .
       
       - name: Upload consolidated release asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -245,7 +245,7 @@ jobs:
         with:
           working-directory: python
           target: ${{ matrix.platform.target }}
-          args: --release --strip --out target/dist --features py-sdk --interpreter python3.11 python3.12 python3.13
+          args: --release --strip --out target/dist --interpreter python3.11 python3.12 python3.13
           sccache: 'true'
           manylinux: ${{ matrix.platform.manylinux || '' }}
 
@@ -271,7 +271,7 @@ jobs:
         with:
           working-directory: python
           command: sdist
-          args: --release --strip --out target/dist --features py-sdk
+          args: --release --strip --out target/dist
           sccache: 'true'
         
       - name: Upload artifacts

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -218,8 +218,8 @@ jobs:
             target: aarch64-apple-darwin
           - runner: windows-latest
             target: x64
-          - runner: windows-latest
-            target: x86
+          # - runner: windows-latest
+          #   target: x86
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -271,7 +271,7 @@ jobs:
         with:
           working-directory: python
           command: sdist
-          args: --release --strip --out target/dist
+          args: --out target/dist
           sccache: 'true'
         
       - name: Upload artifacts

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -245,7 +245,7 @@ jobs:
         with:
           working-directory: python
           target: ${{ matrix.platform.target }}
-          args: --release --strip --out target/dist --features py-sdk --interpreter python3.10 python3.11 python3.12
+          args: --release --sdist --strip --out target/dist --features py-sdk --interpreter python3.11 python3.12 python3.13
           sccache: 'true'
           manylinux: ${{ matrix.platform.manylinux || '' }}
       

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -277,7 +277,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: sdist
-          path: python/target/dist/
+          path: python/target/dist/sdist/kaspa-*.tar.gz
 
   collect-python-sdk-artifacts:
     name: Collect Python SDK Artifacts

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -226,7 +226,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '>=3.11 <=3.13'
+          python-version: '>=3.10 <=3.13'
       
       - name: Install cross-compilation tools (Linux only)
         if: runner.os == 'Linux' && matrix.platform.target != 'x86_64'
@@ -245,7 +245,7 @@ jobs:
         with:
           working-directory: python
           target: ${{ matrix.platform.target }}
-          args: --release --strip --out target/dist --interpreter python3.11 python3.12 python3.13
+          args: --release --strip --out target/dist --interpreter python3.10 python3.11 python3.12 python3.13
           sccache: 'true'
           manylinux: ${{ matrix.platform.manylinux || '' }}
 
@@ -264,7 +264,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '>=3.11 <=3.13'
+          python-version: '>=3.10 <=3.13'
 
       - name: Build sdist
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -270,7 +270,8 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           working-directory: python
-          args: --release --sdist --strip --out target/dist --features py-sdk
+          command: sdist
+          args: --release --strip --out target/dist --features py-sdk
           sccache: 'true'
         
       - name: Upload artifacts

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -245,10 +245,16 @@ jobs:
         with:
           working-directory: python
           target: ${{ matrix.platform.target }}
-          args: --release --sdist --strip --out target/dist --features py-sdk --interpreter python3.11 python3.12 python3.13
+          args: --release --strip --out target/dist --features py-sdk --interpreter python3.11 python3.12 python3.13
           sccache: 'true'
           manylinux: ${{ matrix.platform.manylinux || '' }}
-      
+
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          working-directory: python
+          args: --release --sdist --strip --out target/dist --features py-sdk
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -277,7 +277,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: sdist
-          path: python/target/dist/sdist/kaspa-*.tar.gz
+          path: python/target/dist/kaspa-*.tar.gz
 
   collect-python-sdk-artifacts:
     name: Collect Python SDK Artifacts

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -199,8 +199,8 @@ jobs:
           asset_name: "${{ env.asset_name }}"
           asset_content_type: application/zip
   
-  build-python-sdk:
-    name: Building Python SDK
+  build-python-sdk-wheels:
+    name: Building Python SDK Wheels
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -249,23 +249,41 @@ jobs:
           sccache: 'true'
           manylinux: ${{ matrix.platform.manylinux || '' }}
 
-      - name: Build sdist
-        if: runner.os == 'Linux' && matrix.platform.target == 'x86_64'
-        uses: PyO3/maturin-action@v1
-        with:
-          working-directory: python
-          args: --release --sdist --strip --out target/dist --features py-sdk
-          sccache: 'true'
-
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ runner.os }}-${{ matrix.platform.target }}
           path: python/target/dist/
 
+  build-python-sdk-sdist:
+    name: Build Python SDK sdist
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '>=3.11 <=3.13'
+
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          working-directory: python
+          args: --release --sdist --strip --out target/dist --features py-sdk
+          sccache: 'true'
+        
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: python/target/dist/
+
   collect-python-sdk-artifacts:
     name: Collect Python SDK Artifacts
-    needs: build-python-sdk
+    needs:
+      - build-python-sdk-wheels
+      - build-python-sdk-sdist
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -255,6 +255,7 @@ jobs:
         with:
           working-directory: python
           args: --release --sdist --strip --out target/dist --features py-sdk
+          sccache: 'true'
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/python/build-dev
+++ b/python/build-dev
@@ -22,7 +22,7 @@ else
     maturin --version
 fi
 
-BUILD_CMD="maturin develop --target-dir ./target"
+BUILD_CMD="maturin develop --target-dir target"
 echo "Building with command '$BUILD_CMD'"
 $BUILD_CMD
 

--- a/python/build-dev
+++ b/python/build-dev
@@ -22,7 +22,7 @@ else
     maturin --version
 fi
 
-BUILD_CMD="maturin develop --target-dir ./target --features py-sdk"
+BUILD_CMD="maturin develop --target-dir ./target"
 echo "Building with command '$BUILD_CMD'"
 $BUILD_CMD
 

--- a/python/build-release
+++ b/python/build-release
@@ -22,7 +22,7 @@ else
     maturin --version
 fi
 
-BUILD_CMD="maturin build --release --strip --sdist --target-dir target --out target/wheels --features py-sdk"
+BUILD_CMD="maturin build --release --strip --sdist --target-dir target --out target/wheels"
 echo "Building with command '$BUILD_CMD'"
 $BUILD_CMD
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -29,4 +29,7 @@ name = "kaspa"
 bindings = "pyo3"
 features = ["pyo3/extension-module"]
 strip = true
-include = ["CHANGELOG.md"]
+include = [
+    "LICENSE",
+    "CHANGELOG.md"
+]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -27,7 +27,10 @@ description = "Kaspa Python SDK"
 [tool.maturin]
 name = "kaspa"
 bindings = "pyo3"
-features = ["pyo3/extension-module"]
+features = [
+    "pyo3/extension-module",
+    "py-sdk",
+]
 strip = true
 include = [
     "LICENSE",


### PR DESCRIPTION
- Include sdist in Python SDK release assets
- Clean up build-dev and build-release
- Move py-sdk feature into pyproject.toml
- Release CI updates